### PR TITLE
Async Api; static DataParser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,12 @@ find_package(Boost REQUIRED COMPONENTS system thread)
 ###########
 ## Build ##
 ###########
+option(WITHOUT_LOGGING "Disable all logging" OFF)
 option(WITHOUT_ROS_LOGGING "Disable ROS Logging and use printf instead" ON)
 
-if(WITHOUT_ROS_LOGGING)
+if(WITHOUT_LOGGING)
+  add_definitions(-DNO_LOGGING=1)
+elseif(WITHOUT_ROS_LOGGING)
   add_definitions(-DNO_ROS_LOGGING=1)
 endif()
 

--- a/include/sick_safetyscanners_base/SickSafetyscannersBase.h
+++ b/include/sick_safetyscanners_base/SickSafetyscannersBase.h
@@ -143,8 +143,15 @@ public:
   void asyncChangeSensorSettings(const sick::datastructure::CommSettings& settings,
                                  AsyncCompleteHandler handler);
 
-  void findSensor(const datastructure::CommSettings& settings, uint16_t blink_time);
-  void asyncFindSensor(const datastructure::CommSettings& settings, uint16_t blink_time,
+  /**
+   * \brief Find the sensor by blinking the display on the sensor
+   * \param settings The CommSettings for the sensor
+   * \param blink_time The display on the sensor is blinked by this amount of time. [seconds]
+   */
+  void findSensor(const datastructure::CommSettings& settings,
+                  uint16_t blink_time);
+  void asyncFindSensor(const datastructure::CommSettings& settings,
+                       uint16_t blink_time,
                        AsyncCompleteHandler handler);
 
   /*!

--- a/include/sick_safetyscanners_base/SickSafetyscannersBase.h
+++ b/include/sick_safetyscanners_base/SickSafetyscannersBase.h
@@ -35,9 +35,6 @@
 #ifndef SICK_SAFETYSCANNERS_BASE_SICKSAFETYSCANNERSBASE_H
 #define SICK_SAFETYSCANNERS_BASE_SICKSAFETYSCANNERSBASE_H
 
-//#include <ros/ros.h>
-#include <sick_safetyscanners_base/logging/logging_wrapper.h>
-
 #include <boost/function.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread.hpp>
@@ -45,6 +42,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <future>
 
 #include <sick_safetyscanners_base/communication/AsyncTCPClient.h>
 #include <sick_safetyscanners_base/communication/AsyncUDPClient.h>
@@ -84,6 +82,10 @@ namespace sick {
  */
 class SickSafetyscannersBase
 {
+private:
+  typedef std::promise<boost::system::error_code> CompletePromise;
+  typedef std::shared_ptr<CompletePromise> CompletePromisePtr;
+
 public:
   /*!
    *  Typedef for function which has to be passed to this class. This enables the use of
@@ -91,14 +93,27 @@ public:
    */
   typedef boost::function<void(const sick::datastructure::Data&)> packetReceivedCallbackFunction;
 
+  typedef std::function<void(const boost::system::error_code&)> AsyncCompleteHandler;
+
+  typedef communication::AsyncUDPClient::endpoint_type endpoint_type;
+
   /*!
    * \brief Constructor of the SickSafetyscannersBase class.
    * \param newPacketReceivedCallbackFunction Function from the calling class, which will be
    * called when a new packet is received.
    * \param settings Current settings for the sensor.
    */
-  SickSafetyscannersBase(const packetReceivedCallbackFunction& newPacketReceivedCallbackFunction,
-                         sick::datastructure::CommSettings* settings);
+  SickSafetyscannersBase(const packetReceivedCallbackFunction& newPacketReceivedCallbackFunction );
+
+
+  /**
+   * \brief Constructor of the SickSafetyscannersBase class.
+   * \param io_service
+   * \param newPacketReceivedCallbackFunction Function from the calling class, which will be
+   * called when a new packet is received.
+   */
+  SickSafetyscannersBase(boost::asio::io_service& io_service,
+                         const packetReceivedCallbackFunction& newPacketReceivedCallbackFunction);
 
   /*!
    * \brief Destructor
@@ -109,13 +124,37 @@ public:
    * \brief Start the connection to the sensor and enables output.
    * \return If the setup was correct.
    */
-  bool run();
+  boost::system::error_code start(const sick::datastructure::CommSettings& settings);
+
+  /**
+   * \brief stop
+   */
+  void stop();
+
+  /*!
+   * \brief Returns the actual UDP enpoint settings of local machine
+   * \return The current local UDP endpoint settings
+   */
+  endpoint_type getLocalUdpEndpoint() const;
 
   /*!
    * \brief Changes the internal settings of the sensor.
    * \param settings New set of settings to pass to the sensor.
    */
   void changeSensorSettings(const sick::datastructure::CommSettings& settings);
+  void asyncChangeSensorSettings(const sick::datastructure::CommSettings& settings,
+                                 AsyncCompleteHandler handler);
+
+  /**
+   * \brief Find the sensor by blinking the display on the sensor
+   * \param settings The CommSettings for the sensor
+   * \param blink_time The display on the sensor is blinked by this amount of time. [seconds]
+   */
+  void findSensor(const datastructure::CommSettings& settings,
+                  uint16_t blink_time);
+  void asyncFindSensor(const datastructure::CommSettings& settings,
+                       uint16_t blink_time,
+                       AsyncCompleteHandler handler);
 
   /*!
    * \brief Requests the typecode of the sensor.
@@ -124,39 +163,70 @@ public:
    */
   void requestTypeCode(const sick::datastructure::CommSettings& settings,
                        sick::datastructure::TypeCode& type_code);
+  void asyncRequestTypeCode(const sick::datastructure::CommSettings& settings,
+                            sick::datastructure::TypeCode& type_code,
+                            AsyncCompleteHandler handler);
+
 
   void requestApplicationName(const sick::datastructure::CommSettings& settings,
                               sick::datastructure::ApplicationName& application_name);
+  void asyncRequestApplicationName(const sick::datastructure::CommSettings& settings,
+                                   sick::datastructure::ApplicationName& application_name,
+                                   AsyncCompleteHandler handler);
+
   void requestSerialNumber(const sick::datastructure::CommSettings& settings,
                            sick::datastructure::SerialNumber& serial_number);
+  void asyncRequestSerialNumber(const sick::datastructure::CommSettings& settings,
+                                sick::datastructure::SerialNumber& serial_number,
+                                AsyncCompleteHandler handler);
+
   void requestFirmwareVersion(const sick::datastructure::CommSettings& settings,
                               sick::datastructure::FirmwareVersion& firmware_version);
+  void asyncRequestFirmwareVersion(const sick::datastructure::CommSettings& settings,
+                                   sick::datastructure::FirmwareVersion& firmware_version,
+                                   AsyncCompleteHandler handler);
+
   void requestOrderNumber(const datastructure::CommSettings& settings,
                           datastructure::OrderNumber& order_number);
+  void asyncRequestOrderNumber(const datastructure::CommSettings& settings,
+                               datastructure::OrderNumber& order_number,
+                               AsyncCompleteHandler handler);
+
   void requestProjectName(const datastructure::CommSettings& settings,
                           datastructure::ProjectName& project_name);
+  void asyncRequestProjectName(const datastructure::CommSettings& settings,
+                               datastructure::ProjectName& project_name,
+                               AsyncCompleteHandler handler);
+
   void requestUserName(const datastructure::CommSettings& settings,
                        datastructure::UserName& user_name);
+  void asyncRequestUserName(const datastructure::CommSettings& settings,
+                            datastructure::UserName& user_name,
+                            AsyncCompleteHandler handler);
+
   void requestConfigMetadata(const datastructure::CommSettings& settings,
                              datastructure::ConfigMetadata& config_metadata);
+  void asyncRequestConfigMetadata(const datastructure::CommSettings& settings,
+                                  datastructure::ConfigMetadata& config_metadata,
+                                  AsyncCompleteHandler handler);
+
   void requestStatusOverview(const datastructure::CommSettings& settings,
                              datastructure::StatusOverview& status_overview);
+  void asyncRequestStatusOverview(const datastructure::CommSettings& settings,
+                                  datastructure::StatusOverview& status_overview,
+                                  AsyncCompleteHandler handler);
+
   void requestDeviceStatus(const datastructure::CommSettings& settings,
                            datastructure::DeviceStatus& device_status);
+  void asyncRequestDeviceStatus(const datastructure::CommSettings& settings,
+                                datastructure::DeviceStatus& device_status,
+                                AsyncCompleteHandler handler);
+
   void requestRequiredUserAction(const datastructure::CommSettings& settings,
                                  datastructure::RequiredUserAction& required_user_action);
-  void requestLatestTelegram(const datastructure::CommSettings& settings,
-                             datastructure::Data& data,
-                             int8_t index = 0);
-  void findSensor(const datastructure::CommSettings& settings, uint16_t blink_time);
-  /*!
-   * \brief Requests data of the protective and warning fields from the sensor.
-   *
-   * \param settings Settings containing information to establish a connection to the sensor.
-   * \param field_data Returned field data.
-   */
-  void requestFieldData(const sick::datastructure::CommSettings& settings,
-                        std::vector<sick::datastructure::FieldData>& field_data);
+  void asyncRequestRequiredUserAction(const datastructure::CommSettings& settings,
+                                      datastructure::RequiredUserAction& required_user_action,
+                                      AsyncCompleteHandler handler);
 
   /*!
    * \brief Requests the name of the device from the sensor.
@@ -166,6 +236,22 @@ public:
    */
   void requestDeviceName(const sick::datastructure::CommSettings& settings,
                          datastructure::DeviceName& device_name);
+  void asyncRequestDeviceName(const sick::datastructure::CommSettings& settings,
+                              datastructure::DeviceName& device_name,
+                              AsyncCompleteHandler handler);
+
+
+  /*!
+   * \brief Requests data of the protective and warning fields from the sensor.
+   *
+   * \param settings Settings containing information to establish a connection to the sensor.
+   * \param field_data Returned field data.
+   */
+  void requestFieldData(const sick::datastructure::CommSettings& settings,
+                        std::vector<sick::datastructure::FieldData>& field_data);
+  void asyncRequestFieldData(const sick::datastructure::CommSettings& settings,
+                             std::vector<sick::datastructure::FieldData>& field_data,
+                             AsyncCompleteHandler handler);
 
   /*!
    * \brief Requests the persistent configuration from the sensor.
@@ -175,55 +261,35 @@ public:
    */
   void requestPersistentConfig(const datastructure::CommSettings& settings,
                                sick::datastructure::ConfigData& config_data);
+  void asyncRequestPersistentConfig(const datastructure::CommSettings& settings,
+                                    sick::datastructure::ConfigData& config_data,
+                                    AsyncCompleteHandler handler);
+
   /*!
    * \brief Requests the monitoring cases from the sensor.
    *
    * \param settings Settings containing information to establish a connection to the sensor.
    * \param monitoring_cases Returned monitoring cases.
    */
-  void
-  requestMonitoringCases(const sick::datastructure::CommSettings& settings,
-                         std::vector<sick::datastructure::MonitoringCaseData>& monitoring_cases);
-
+  void requestMonitoringCases(const sick::datastructure::CommSettings& settings,
+                              std::vector<sick::datastructure::MonitoringCaseData>& monitoring_cases);
+  void asyncRequestMonitoringCases(const sick::datastructure::CommSettings& settings,
+                                   std::vector<sick::datastructure::MonitoringCaseData>& monitoring_cases,
+                                   AsyncCompleteHandler handler);
 
 private:
   packetReceivedCallbackFunction m_newPacketReceivedCallbackFunction;
 
   std::shared_ptr<boost::asio::io_service> m_io_service_ptr;
-  std::shared_ptr<boost::asio::io_service::work> m_io_work_ptr;
-  std::shared_ptr<sick::communication::AsyncUDPClient> m_async_udp_client_ptr;
-  std::shared_ptr<sick::communication::AsyncTCPClient> m_async_tcp_client_ptr;
-  boost::scoped_ptr<boost::thread> m_udp_client_thread_ptr;
+  boost::reference_wrapper< boost::asio::io_service > m_io_service;
 
-  std::shared_ptr<sick::cola2::Cola2Session> m_session_ptr;
+  std::shared_ptr<sick::communication::AsyncUDPClient> m_async_udp_client_ptr;
+  boost::scoped_ptr<boost::thread> m_udp_client_thread_ptr;
 
   std::shared_ptr<sick::data_processing::UDPPacketMerger> m_packet_merger_ptr;
 
   void processUDPPacket(const sick::datastructure::PacketBuffer& buffer);
   bool udpClientThread();
-  void processTCPPacket(const sick::datastructure::PacketBuffer& buffer);
-  void startTCPConnection(const sick::datastructure::CommSettings& settings);
-  void changeCommSettingsInColaSession(const datastructure::CommSettings& settings);
-  void stopTCPConnection();
-  void requestTypeCodeInColaSession(sick::datastructure::TypeCode& type_code);
-  void requestFieldDataInColaSession(std::vector<sick::datastructure::FieldData>& fields);
-  void requestDeviceNameInColaSession(datastructure::DeviceName& device_name);
-  void requestApplicationNameInColaSession(sick::datastructure::ApplicationName& application_name);
-  void requestSerialNumberInColaSession(sick::datastructure::SerialNumber& serial_number);
-  void requestOrderNumberInColaSession(sick::datastructure::OrderNumber& order_number);
-  void requestProjectNameInColaSession(sick::datastructure::ProjectName& project_name);
-  void requestUserNameInColaSession(sick::datastructure::UserName& user_name);
-  void requestFirmwareVersionInColaSession(sick::datastructure::FirmwareVersion& firmware_version);
-  void requestPersistentConfigInColaSession(sick::datastructure::ConfigData& config_data);
-  void requestConfigMetadataInColaSession(sick::datastructure::ConfigMetadata& config_metadata);
-  void requestStatusOverviewInColaSession(sick::datastructure::StatusOverview& status_overview);
-  void requestDeviceStatusInColaSession(sick::datastructure::DeviceStatus& device_status);
-  void requestRequiredUserActionInColaSession(
-    sick::datastructure::RequiredUserAction& required_user_action);
-  void requestMonitoringCaseDataInColaSession(
-    std::vector<sick::datastructure::MonitoringCaseData>& monitoring_cases);
-  void requestLatestTelegramInColaSession(sick::datastructure::Data& data, int8_t index = 0);
-  void findSensorInColaSession(uint16_t blink_time);
 };
 
 } // namespace sick

--- a/include/sick_safetyscanners_base/SickSafetyscannersBase.h
+++ b/include/sick_safetyscanners_base/SickSafetyscannersBase.h
@@ -35,9 +35,6 @@
 #ifndef SICK_SAFETYSCANNERS_BASE_SICKSAFETYSCANNERSBASE_H
 #define SICK_SAFETYSCANNERS_BASE_SICKSAFETYSCANNERSBASE_H
 
-//#include <ros/ros.h>
-#include <sick_safetyscanners_base/logging/logging_wrapper.h>
-
 #include <boost/function.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread.hpp>

--- a/include/sick_safetyscanners_base/SickSafetyscannersBase.h
+++ b/include/sick_safetyscanners_base/SickSafetyscannersBase.h
@@ -42,6 +42,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <future>
 
 #include <sick_safetyscanners_base/communication/AsyncTCPClient.h>
 #include <sick_safetyscanners_base/communication/AsyncUDPClient.h>
@@ -80,12 +81,18 @@ namespace sick {
  */
 class SickSafetyscannersBase
 {
+private:
+  typedef std::promise<boost::system::error_code> CompletePromise;
+  typedef std::shared_ptr<CompletePromise> CompletePromisePtr;
+
 public:
   /*!
    *  Typedef for function which has to be passed to this class. This enables the use of
    *  functions from the calling class.
    */
   typedef boost::function<void(const sick::datastructure::Data&)> packetReceivedCallbackFunction;
+
+  typedef std::function<void(const boost::system::error_code&)> AsyncCompleteHandler;
 
   /*!
    * \brief Constructor of the SickSafetyscannersBase class.
@@ -112,6 +119,12 @@ public:
    * \param settings New set of settings to pass to the sensor.
    */
   void changeSensorSettings(const sick::datastructure::CommSettings& settings);
+  void asyncChangeSensorSettings(const sick::datastructure::CommSettings& settings,
+                                 AsyncCompleteHandler handler);
+
+  void findSensor(const datastructure::CommSettings& settings, uint16_t blink_time);
+  void asyncFindSensor(const datastructure::CommSettings& settings, uint16_t blink_time,
+                       AsyncCompleteHandler handler);
 
   /*!
    * \brief Requests the typecode of the sensor.
@@ -120,36 +133,70 @@ public:
    */
   void requestTypeCode(const sick::datastructure::CommSettings& settings,
                        sick::datastructure::TypeCode& type_code);
+  void asyncRequestTypeCode(const sick::datastructure::CommSettings& settings,
+                            sick::datastructure::TypeCode& type_code,
+                            AsyncCompleteHandler handler);
+
 
   void requestApplicationName(const sick::datastructure::CommSettings& settings,
                               sick::datastructure::ApplicationName& application_name);
+  void asyncRequestApplicationName(const sick::datastructure::CommSettings& settings,
+                                   sick::datastructure::ApplicationName& application_name,
+                                   AsyncCompleteHandler handler);
+
   void requestSerialNumber(const sick::datastructure::CommSettings& settings,
                            sick::datastructure::SerialNumber& serial_number);
+  void asyncRequestSerialNumber(const sick::datastructure::CommSettings& settings,
+                                sick::datastructure::SerialNumber& serial_number,
+                                AsyncCompleteHandler handler);
+
   void requestFirmwareVersion(const sick::datastructure::CommSettings& settings,
                               sick::datastructure::FirmwareVersion& firmware_version);
+  void asyncRequestFirmwareVersion(const sick::datastructure::CommSettings& settings,
+                                   sick::datastructure::FirmwareVersion& firmware_version,
+                                   AsyncCompleteHandler handler);
+
   void requestOrderNumber(const datastructure::CommSettings& settings,
                           datastructure::OrderNumber& order_number);
+  void asyncRequestOrderNumber(const datastructure::CommSettings& settings,
+                               datastructure::OrderNumber& order_number,
+                               AsyncCompleteHandler handler);
+
   void requestProjectName(const datastructure::CommSettings& settings,
                           datastructure::ProjectName& project_name);
+  void asyncRequestProjectName(const datastructure::CommSettings& settings,
+                               datastructure::ProjectName& project_name,
+                               AsyncCompleteHandler handler);
+
   void requestUserName(const datastructure::CommSettings& settings,
                        datastructure::UserName& user_name);
+  void asyncRequestUserName(const datastructure::CommSettings& settings,
+                            datastructure::UserName& user_name,
+                            AsyncCompleteHandler handler);
+
   void requestConfigMetadata(const datastructure::CommSettings& settings,
                              datastructure::ConfigMetadata& config_metadata);
+  void asyncRequestConfigMetadata(const datastructure::CommSettings& settings,
+                                  datastructure::ConfigMetadata& config_metadata,
+                                  AsyncCompleteHandler handler);
+
   void requestStatusOverview(const datastructure::CommSettings& settings,
                              datastructure::StatusOverview& status_overview);
+  void asyncRequestStatusOverview(const datastructure::CommSettings& settings,
+                                  datastructure::StatusOverview& status_overview,
+                                  AsyncCompleteHandler handler);
+
   void requestDeviceStatus(const datastructure::CommSettings& settings,
                            datastructure::DeviceStatus& device_status);
+  void asyncRequestDeviceStatus(const datastructure::CommSettings& settings,
+                                datastructure::DeviceStatus& device_status,
+                                AsyncCompleteHandler handler);
+
   void requestRequiredUserAction(const datastructure::CommSettings& settings,
                                  datastructure::RequiredUserAction& required_user_action);
-  void findSensor(const datastructure::CommSettings& settings, uint16_t blink_time);
-  /*!
-   * \brief Requests data of the protective and warning fields from the sensor.
-   *
-   * \param settings Settings containing information to establish a connection to the sensor.
-   * \param field_data Returned field data.
-   */
-  void requestFieldData(const sick::datastructure::CommSettings& settings,
-                        std::vector<sick::datastructure::FieldData>& field_data);
+  void asyncRequestRequiredUserAction(const datastructure::CommSettings& settings,
+                                      datastructure::RequiredUserAction& required_user_action,
+                                      AsyncCompleteHandler handler);
 
   /*!
    * \brief Requests the name of the device from the sensor.
@@ -159,6 +206,22 @@ public:
    */
   void requestDeviceName(const sick::datastructure::CommSettings& settings,
                          datastructure::DeviceName& device_name);
+  void asyncRequestDeviceName(const sick::datastructure::CommSettings& settings,
+                              datastructure::DeviceName& device_name,
+                              AsyncCompleteHandler handler);
+
+
+  /*!
+   * \brief Requests data of the protective and warning fields from the sensor.
+   *
+   * \param settings Settings containing information to establish a connection to the sensor.
+   * \param field_data Returned field data.
+   */
+  void requestFieldData(const sick::datastructure::CommSettings& settings,
+                        std::vector<sick::datastructure::FieldData>& field_data);
+  void asyncRequestFieldData(const sick::datastructure::CommSettings& settings,
+                             std::vector<sick::datastructure::FieldData>& field_data,
+                             AsyncCompleteHandler handler);
 
   /*!
    * \brief Requests the persistent configuration from the sensor.
@@ -168,16 +231,21 @@ public:
    */
   void requestPersistentConfig(const datastructure::CommSettings& settings,
                                sick::datastructure::ConfigData& config_data);
+  void asyncRequestPersistentConfig(const datastructure::CommSettings& settings,
+                                    sick::datastructure::ConfigData& config_data,
+                                    AsyncCompleteHandler handler);
+
   /*!
    * \brief Requests the monitoring cases from the sensor.
    *
    * \param settings Settings containing information to establish a connection to the sensor.
    * \param monitoring_cases Returned monitoring cases.
    */
-  void
-  requestMonitoringCases(const sick::datastructure::CommSettings& settings,
-                         std::vector<sick::datastructure::MonitoringCaseData>& monitoring_cases);
-
+  void requestMonitoringCases(const sick::datastructure::CommSettings& settings,
+                              std::vector<sick::datastructure::MonitoringCaseData>& monitoring_cases);
+  void asyncRequestMonitoringCases(const sick::datastructure::CommSettings& settings,
+                                   std::vector<sick::datastructure::MonitoringCaseData>& monitoring_cases,
+                                   AsyncCompleteHandler handler);
 
 private:
   packetReceivedCallbackFunction m_newPacketReceivedCallbackFunction;
@@ -185,37 +253,12 @@ private:
   std::shared_ptr<boost::asio::io_service> m_io_service_ptr;
   std::shared_ptr<boost::asio::io_service::work> m_io_work_ptr;
   std::shared_ptr<sick::communication::AsyncUDPClient> m_async_udp_client_ptr;
-  std::shared_ptr<sick::communication::AsyncTCPClient> m_async_tcp_client_ptr;
   boost::scoped_ptr<boost::thread> m_udp_client_thread_ptr;
-
-  std::shared_ptr<sick::cola2::Cola2Session> m_session_ptr;
 
   std::shared_ptr<sick::data_processing::UDPPacketMerger> m_packet_merger_ptr;
 
   void processUDPPacket(const sick::datastructure::PacketBuffer& buffer);
   bool udpClientThread();
-  void processTCPPacket(const sick::datastructure::PacketBuffer& buffer);
-  void startTCPConnection(const sick::datastructure::CommSettings& settings);
-  void changeCommSettingsInColaSession(const datastructure::CommSettings& settings);
-  void stopTCPConnection();
-  void requestTypeCodeInColaSession(sick::datastructure::TypeCode& type_code);
-  void requestFieldDataInColaSession(std::vector<sick::datastructure::FieldData>& fields);
-  void requestDeviceNameInColaSession(datastructure::DeviceName& device_name);
-  void requestApplicationNameInColaSession(sick::datastructure::ApplicationName& application_name);
-  void requestSerialNumberInColaSession(sick::datastructure::SerialNumber& serial_number);
-  void requestOrderNumberInColaSession(sick::datastructure::OrderNumber& order_number);
-  void requestProjectNameInColaSession(sick::datastructure::ProjectName& project_name);
-  void requestUserNameInColaSession(sick::datastructure::UserName& user_name);
-  void requestFirmwareVersionInColaSession(sick::datastructure::FirmwareVersion& firmware_version);
-  void requestPersistentConfigInColaSession(sick::datastructure::ConfigData& config_data);
-  void requestConfigMetadataInColaSession(sick::datastructure::ConfigMetadata& config_metadata);
-  void requestStatusOverviewInColaSession(sick::datastructure::StatusOverview& status_overview);
-  void requestDeviceStatusInColaSession(sick::datastructure::DeviceStatus& device_status);
-  void requestRequiredUserActionInColaSession(
-    sick::datastructure::RequiredUserAction& required_user_action);
-  void requestMonitoringCaseDataInColaSession(
-    std::vector<sick::datastructure::MonitoringCaseData>& monitoring_cases);
-  void findSensorInColaSession(uint16_t blink_time);
 };
 
 } // namespace sick

--- a/include/sick_safetyscanners_base/SickSafetyscannersBase.h
+++ b/include/sick_safetyscanners_base/SickSafetyscannersBase.h
@@ -228,6 +228,14 @@ public:
                                       datastructure::RequiredUserAction& required_user_action,
                                       AsyncCompleteHandler handler);
 
+  void requestLatestTelegram(const datastructure::CommSettings& settings,
+                             datastructure::Data& data,
+                             int8_t index = 0);
+  void asyncRequestLatestTelegram(const datastructure::CommSettings& settings,
+                                  datastructure::Data& data,
+                                  int8_t index,
+                                  AsyncCompleteHandler handler);
+
   /*!
    * \brief Requests the name of the device from the sensor.
    *

--- a/include/sick_safetyscanners_base/SickSafetyscannersBase.h
+++ b/include/sick_safetyscanners_base/SickSafetyscannersBase.h
@@ -94,14 +94,14 @@ public:
 
   typedef std::function<void(const boost::system::error_code&)> AsyncCompleteHandler;
 
+  typedef communication::AsyncUDPClient::endpoint_type endpoint_type;
+
   /*!
    * \brief Constructor of the SickSafetyscannersBase class.
    * \param newPacketReceivedCallbackFunction Function from the calling class, which will be
    * called when a new packet is received.
-   * \param settings Current settings for the sensor.
    */
-  SickSafetyscannersBase(const packetReceivedCallbackFunction& newPacketReceivedCallbackFunction,
-                         sick::datastructure::CommSettings* settings);
+  SickSafetyscannersBase(const packetReceivedCallbackFunction& newPacketReceivedCallbackFunction );
 
 
   /**
@@ -109,11 +109,9 @@ public:
    * \param io_service
    * \param newPacketReceivedCallbackFunction Function from the calling class, which will be
    * called when a new packet is received.
-   * \param settings Current settings for the sensor.
    */
   SickSafetyscannersBase(boost::asio::io_service& io_service,
-                         const packetReceivedCallbackFunction& newPacketReceivedCallbackFunction,
-                         sick::datastructure::CommSettings* settings);
+                         const packetReceivedCallbackFunction& newPacketReceivedCallbackFunction);
 
   /*!
    * \brief Destructor
@@ -124,12 +122,18 @@ public:
    * \brief Start the connection to the sensor and enables output.
    * \return If the setup was correct.
    */
-  bool run();
+  boost::system::error_code start(const sick::datastructure::CommSettings& settings);
 
   /**
    * \brief stop
    */
   void stop();
+
+  /*!
+   * \brief Returns the actual UDP enpoint settings of local machine
+   * \return The current local UDP endpoint settings
+   */
+  endpoint_type getLocalUdpEndpoint() const;
 
   /*!
    * \brief Changes the internal settings of the sensor.

--- a/include/sick_safetyscanners_base/SickSafetyscannersBase.h
+++ b/include/sick_safetyscanners_base/SickSafetyscannersBase.h
@@ -103,6 +103,18 @@ public:
   SickSafetyscannersBase(const packetReceivedCallbackFunction& newPacketReceivedCallbackFunction,
                          sick::datastructure::CommSettings* settings);
 
+
+  /**
+   * \brief Constructor of the SickSafetyscannersBase class.
+   * \param io_service
+   * \param newPacketReceivedCallbackFunction Function from the calling class, which will be
+   * called when a new packet is received.
+   * \param settings Current settings for the sensor.
+   */
+  SickSafetyscannersBase(boost::asio::io_service& io_service,
+                         const packetReceivedCallbackFunction& newPacketReceivedCallbackFunction,
+                         sick::datastructure::CommSettings* settings);
+
   /*!
    * \brief Destructor
    */
@@ -113,6 +125,11 @@ public:
    * \return If the setup was correct.
    */
   bool run();
+
+  /**
+   * \brief stop
+   */
+  void stop();
 
   /*!
    * \brief Changes the internal settings of the sensor.
@@ -251,7 +268,8 @@ private:
   packetReceivedCallbackFunction m_newPacketReceivedCallbackFunction;
 
   std::shared_ptr<boost::asio::io_service> m_io_service_ptr;
-  std::shared_ptr<boost::asio::io_service::work> m_io_work_ptr;
+  boost::reference_wrapper< boost::asio::io_service > m_io_service;
+
   std::shared_ptr<sick::communication::AsyncUDPClient> m_async_udp_client_ptr;
   boost::scoped_ptr<boost::thread> m_udp_client_thread_ptr;
 

--- a/include/sick_safetyscanners_base/cola2/ApplicationNameVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/ApplicationNameVariableCommand.h
@@ -81,8 +81,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseApplicationNameData> m_application_name_parser_ptr;
-
   sick::datastructure::ApplicationName& m_application_name;
 };
 

--- a/include/sick_safetyscanners_base/cola2/Cola2Session.h
+++ b/include/sick_safetyscanners_base/cola2/Cola2Session.h
@@ -141,9 +141,7 @@ public:
 
 private:
   std::shared_ptr<sick::communication::AsyncTCPClient> m_async_tcp_client_ptr;
-  std::shared_ptr<sick::data_processing::ParseTCPPacket> m_parser_ptr;
   std::shared_ptr<sick::data_processing::TCPPacketMerger> m_packet_merger_ptr;
-  std::shared_ptr<sick::data_processing::ParseTCPPacket> m_tcp_parser_ptr;
 
   std::map<uint16_t, CommandPtr> m_pending_commands_map;
 

--- a/include/sick_safetyscanners_base/cola2/Cola2Session.h
+++ b/include/sick_safetyscanners_base/cola2/Cola2Session.h
@@ -77,6 +77,8 @@ public:
    */
   typedef std::shared_ptr<sick::cola2::Command> CommandPtr;
 
+  typedef std::function<void(const boost::system::error_code&)> CompleteHandler;
+
   /*!
    * \brief Constructor of the cola2 session.
    *
@@ -85,11 +87,26 @@ public:
    */
   explicit Cola2Session(const std::shared_ptr<communication::AsyncTCPClient>& async_tcp_client);
 
+  ~Cola2Session();
+
+  /*!
+   * \brief Opens a session with the sensor. Executes the create session command.
+   *
+   * \returns If opening a session was successful.
+   */
+  bool open(CompleteHandler handler);
+
+  /*!
+   * \brief Closes a session with the sensor. Executes the close session command.
+   *
+   * \returns If closing the session was successful.
+   */
+  bool close(CompleteHandler handler);
 
   /*!
    * \brief Triggers the disconnection of the tcp socket.
    */
-  void doDisconnect();
+  boost::system::error_code doDisconnect();
 
   /*!
    * \brief Executes the command passed to the function.
@@ -98,7 +115,7 @@ public:
    *
    * \returns If the execution was successful.
    */
-  bool executeCommand(const CommandPtr& command);
+  bool executeCommand(const CommandPtr& command, CompleteHandler handler);
 
   /*!
    * \brief Returns the current session ID.
@@ -123,36 +140,19 @@ public:
   uint16_t getNextRequestID();
 
 
-  /*!
-   * \brief Closes a session with the sensor. Executes the close session command.
-   *
-   * \returns If closing the session was successful.
-   */
-  bool close();
-
-
-  /*!
-   * \brief Opens a session with the sensor. Executes the create session command.
-   *
-   * \returns If opening a session was successful.
-   */
-  bool open();
-
-
 private:
   std::shared_ptr<sick::communication::AsyncTCPClient> m_async_tcp_client_ptr;
-  std::shared_ptr<sick::data_processing::ParseTCPPacket> m_parser_ptr;
   std::shared_ptr<sick::data_processing::TCPPacketMerger> m_packet_merger_ptr;
-  std::shared_ptr<sick::data_processing::ParseTCPPacket> m_tcp_parser_ptr;
 
+  boost::mutex m_pending_commands_map_mutex;
   std::map<uint16_t, CommandPtr> m_pending_commands_map;
-
-  boost::mutex m_execution_mutex;
 
   uint32_t m_session_id;
   uint16_t m_last_request_id;
 
-  void processPacket(const sick::datastructure::PacketBuffer& packet);
+  void processPacket(const sick::datastructure::PacketBuffer& packet,
+                     const boost::system::error_code& ec,
+                     CompleteHandler handler);
 
   bool addCommand(const uint16_t& request_id, const CommandPtr& command);
   bool findCommand(const uint16_t& request_id, CommandPtr& command);
@@ -161,8 +161,7 @@ private:
   bool
   startProcessingAndRemovePendingCommandAfterwards(const sick::datastructure::PacketBuffer& packet);
   bool addPacketToMerger(const sick::datastructure::PacketBuffer& packet);
-  bool checkIfPacketIsCompleteAndOtherwiseListenForMorePackets();
-  bool sendTelegramAndListenForAnswer(const CommandPtr& command);
+  void sendTelegramAndListenForAnswer(const CommandPtr& command, CompleteHandler handler);
 };
 
 

--- a/include/sick_safetyscanners_base/cola2/Command.h
+++ b/include/sick_safetyscanners_base/cola2/Command.h
@@ -35,9 +35,6 @@
 #ifndef SICK_SAFETYSCANNERS_BASE_COLA2_COMMAND_H
 #define SICK_SAFETYSCANNERS_BASE_COLA2_COMMAND_H
 
-//#include <ros/ros.h>
-#include <sick_safetyscanners_base/logging/logging_wrapper.h>
-
 #include <vector>
 
 #include <sick_safetyscanners_base/datastructure/PacketBuffer.h>
@@ -79,12 +76,6 @@ public:
    */
   virtual ~Command() {}
 
-
-  /*!
-   * \brief Locks a mutex to prevent other commands being executed in parallel.
-   */
-  void lockExecutionMutex();
-
   /*!
    * \brief Adds the data to the telegram and afterwards the header with the correct length.
    *
@@ -101,13 +92,6 @@ public:
    * \param packet The incoming data package which will be processed.
    */
   void processReplyBase(const std::vector<uint8_t>& packet);
-
-
-  /*!
-   * \brief Scooped call to the mutex, which will block until the reply was processed.
-   */
-  void waitForCompletion();
-
 
   /*!
    * \brief Returns the current session ID.
@@ -131,7 +115,6 @@ public:
    * \returns If the command was successfully parsed.
    */
   bool wasSuccessful() const;
-
 
   /*!
    * \brief Returns the command type.
@@ -196,10 +179,6 @@ protected:
                                       size_t additional_bytes) const;
 
 private:
-  std::shared_ptr<sick::data_processing::ParseTCPPacket> m_tcp_parser_ptr;
-
-  boost::mutex m_execution_mutex;
-
   bool m_was_successful;
 
   uint8_t m_command_mode;

--- a/include/sick_safetyscanners_base/cola2/Command.h
+++ b/include/sick_safetyscanners_base/cola2/Command.h
@@ -35,9 +35,6 @@
 #ifndef SICK_SAFETYSCANNERS_BASE_COLA2_COMMAND_H
 #define SICK_SAFETYSCANNERS_BASE_COLA2_COMMAND_H
 
-//#include <ros/ros.h>
-#include <sick_safetyscanners_base/logging/logging_wrapper.h>
-
 #include <vector>
 
 #include <sick_safetyscanners_base/datastructure/PacketBuffer.h>

--- a/include/sick_safetyscanners_base/cola2/Command.h
+++ b/include/sick_safetyscanners_base/cola2/Command.h
@@ -76,12 +76,6 @@ public:
    */
   virtual ~Command() {}
 
-
-  /*!
-   * \brief Locks a mutex to prevent other commands being executed in parallel.
-   */
-  void lockExecutionMutex();
-
   /*!
    * \brief Adds the data to the telegram and afterwards the header with the correct length.
    *
@@ -98,13 +92,6 @@ public:
    * \param packet The incoming data package which will be processed.
    */
   void processReplyBase(const std::vector<uint8_t>& packet);
-
-
-  /*!
-   * \brief Scooped call to the mutex, which will block until the reply was processed.
-   */
-  void waitForCompletion();
-
 
   /*!
    * \brief Returns the current session ID.
@@ -128,7 +115,6 @@ public:
    * \returns If the command was successfully parsed.
    */
   bool wasSuccessful() const;
-
 
   /*!
    * \brief Returns the command type.
@@ -193,8 +179,6 @@ protected:
                                       size_t additional_bytes) const;
 
 private:
-  boost::mutex m_execution_mutex;
-
   bool m_was_successful;
 
   uint8_t m_command_mode;

--- a/include/sick_safetyscanners_base/cola2/Command.h
+++ b/include/sick_safetyscanners_base/cola2/Command.h
@@ -196,8 +196,6 @@ protected:
                                       size_t additional_bytes) const;
 
 private:
-  std::shared_ptr<sick::data_processing::ParseTCPPacket> m_tcp_parser_ptr;
-
   boost::mutex m_execution_mutex;
 
   bool m_was_successful;

--- a/include/sick_safetyscanners_base/cola2/ConfigMetadataVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/ConfigMetadataVariableCommand.h
@@ -81,8 +81,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseConfigMetadata> m_config_metadata_parser_ptr;
-
   sick::datastructure::ConfigMetadata& m_config_metadata;
 };
 

--- a/include/sick_safetyscanners_base/cola2/DeviceNameVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/DeviceNameVariableCommand.h
@@ -78,8 +78,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseDeviceName> m_device_name_parser_ptr;
-
   datastructure::DeviceName& m_device_name;
 };
 

--- a/include/sick_safetyscanners_base/cola2/DeviceStatusVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/DeviceStatusVariableCommand.h
@@ -80,8 +80,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseDeviceStatusData> m_device_status_parser_ptr;
-
   sick::datastructure::DeviceStatus& m_device_status;
 };
 

--- a/include/sick_safetyscanners_base/cola2/FieldGeometryVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/FieldGeometryVariableCommand.h
@@ -86,8 +86,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseFieldGeometryData> m_field_geometry_parser_ptr;
-
   sick::datastructure::FieldData& m_field_data;
 };
 

--- a/include/sick_safetyscanners_base/cola2/FieldHeaderVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/FieldHeaderVariableCommand.h
@@ -86,8 +86,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseFieldHeaderData> m_field_header_parser_ptr;
-
   sick::datastructure::FieldData& m_field_data;
 };
 

--- a/include/sick_safetyscanners_base/cola2/FieldSetsVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/FieldSetsVariableCommand.h
@@ -80,8 +80,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseFieldSetsData> m_field_sets_parser_ptr;
-
   sick::datastructure::FieldSets& m_field_sets;
 };
 

--- a/include/sick_safetyscanners_base/cola2/FirmwareVersionVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/FirmwareVersionVariableCommand.h
@@ -81,8 +81,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseFirmwareVersion> m_firmware_version_parser_ptr;
-
   datastructure::FirmwareVersion& m_firmware_version;
 };
 

--- a/include/sick_safetyscanners_base/cola2/LatestTelegramVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/LatestTelegramVariableCommand.h
@@ -82,8 +82,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseData> m_data_parser_ptr;
-
   datastructure::Data& m_data;
 };
 

--- a/include/sick_safetyscanners_base/cola2/MeasurementCurrentConfigVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/MeasurementCurrentConfigVariableCommand.h
@@ -83,9 +83,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseMeasurementCurrentConfigData>
-    m_measurement_current_config_parser_ptr;
-
   sick::datastructure::ConfigData& m_config_data;
 };
 

--- a/include/sick_safetyscanners_base/cola2/MeasurementPersistentConfigVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/MeasurementPersistentConfigVariableCommand.h
@@ -84,9 +84,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseMeasurementPersistentConfigData>
-    m_measurement_persistent_config_parser_ptr;
-
   sick::datastructure::ConfigData& m_config_data;
 };
 

--- a/include/sick_safetyscanners_base/cola2/MonitoringCaseTableHeaderVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/MonitoringCaseTableHeaderVariableCommand.h
@@ -81,9 +81,7 @@ public:
    */
   bool processReply();
 
-
 private:
-  std::shared_ptr<sick::data_processing::ParseFieldHeaderData> m_field_header_parser_ptr;
 };
 
 } // namespace cola2

--- a/include/sick_safetyscanners_base/cola2/MonitoringCaseVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/MonitoringCaseVariableCommand.h
@@ -84,8 +84,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseMonitoringCaseData> m_monitoring_case_parser_ptr;
-
   sick::datastructure::MonitoringCaseData& m_monitoring_case_data;
 };
 

--- a/include/sick_safetyscanners_base/cola2/OrderNumberVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/OrderNumberVariableCommand.h
@@ -79,8 +79,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseOrderNumber> m_order_number_parser_ptr;
-
   datastructure::OrderNumber& m_order_number;
 };
 

--- a/include/sick_safetyscanners_base/cola2/ProjectNameVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/ProjectNameVariableCommand.h
@@ -79,8 +79,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseProjectName> m_project_name_parser_ptr;
-
   datastructure::ProjectName& m_project_name;
 };
 

--- a/include/sick_safetyscanners_base/cola2/RequiredUserActionVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/RequiredUserActionVariableCommand.h
@@ -81,9 +81,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseRequiredUserActionData>
-    m_required_user_action_parser_ptr;
-
   sick::datastructure::RequiredUserAction& m_required_user_action;
 };
 

--- a/include/sick_safetyscanners_base/cola2/SerialNumberVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/SerialNumberVariableCommand.h
@@ -79,8 +79,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseSerialNumber> m_serial_number_parser_ptr;
-
   datastructure::SerialNumber& m_serial_number;
 };
 

--- a/include/sick_safetyscanners_base/cola2/StatusOverviewVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/StatusOverviewVariableCommand.h
@@ -81,8 +81,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseStatusOverviewData> m_status_overview_parser_ptr;
-
   sick::datastructure::StatusOverview& m_status_overview;
 };
 

--- a/include/sick_safetyscanners_base/cola2/TypeCodeVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/TypeCodeVariableCommand.h
@@ -79,8 +79,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseTypeCodeData> m_type_code_parser_ptr;
-
   sick::datastructure::TypeCode& m_type_code;
 };
 

--- a/include/sick_safetyscanners_base/cola2/UserNameVariableCommand.h
+++ b/include/sick_safetyscanners_base/cola2/UserNameVariableCommand.h
@@ -80,8 +80,6 @@ public:
 
 
 private:
-  std::shared_ptr<sick::data_processing::ParseUserNameData> m_user_name_parser_ptr;
-
   sick::datastructure::UserName& m_user_name;
 };
 

--- a/include/sick_safetyscanners_base/communication/AsyncTCPClient.h
+++ b/include/sick_safetyscanners_base/communication/AsyncTCPClient.h
@@ -64,7 +64,9 @@ public:
    * \brief Typedef to a function referencing a packet handler. This can be passed to the class and
    * therefore be called on processing the data.
    */
-  typedef boost::function<void(const sick::datastructure::PacketBuffer&)> PacketHandler;
+  typedef std::function<void(const sick::datastructure::PacketBuffer&, const boost::system::error_code&)> PacketHandler;
+
+  typedef std::function<void(const boost::system::error_code&)> CompleteHandler;
 
   /*!
    * \brief Constructor of the asynchronous tcp client.
@@ -74,8 +76,7 @@ public:
    * \param server_ip The IP address of the server to connect to.
    * \param server_port The port on the server to connect to.
    */
-  AsyncTCPClient(const PacketHandler& packet_handler,
-                 boost::asio::io_service& io_service,
+  AsyncTCPClient(boost::asio::io_service& io_service,
                  const boost::asio::ip::address_v4& server_ip,
                  const uint16_t& server_port);
 
@@ -87,36 +88,28 @@ public:
   /*!
    * \brief Establishes a connection from the host to the sensor.
    */
-  void doConnect();
+  void doConnect( CompleteHandler handler );
 
   /*!
    * \brief Disconnects the host from the sensor
    */
-  void doDisconnect();
+  boost::system::error_code doDisconnect();
 
   /*!
    * \brief Start a cycle of sensing a command and waiting got the return.
    *
    * \param sendBuffer The telegram which will be sent to the server.
    */
-  void doSendAndReceive(const std::vector<uint8_t>& sendBuffer);
+  void send(const std::vector<uint8_t>& sendBuffer, CompleteHandler handler);
 
   /*!
    * \brief Initiates the listening for a message from the server.
    */
-  void initiateReceive();
+  void readSome( PacketHandler handler );
 
-  /*!
-   * \brief Sets the packet handler function.
-   *
-   * \param packet_handler The new packet handler function.
-   */
-  void setPacketHandler(const PacketHandler& packet_handler);
 
 private:
   datastructure::PacketBuffer::ArrayBuffer m_recv_buffer;
-
-  PacketHandler m_packet_handler;
 
   std::shared_ptr<boost::asio::io_service::work> m_io_work_ptr;
   boost::asio::io_service& m_io_service;
@@ -128,9 +121,7 @@ private:
   boost::mutex m_connect_mutex;
   boost::mutex m_socket_mutex;
 
-  void startReceive();
-  void handleReceive(const boost::system::error_code& error, const std::size_t& bytes_transferred);
-
+  void handleReceive( PacketHandler handler, const boost::system::error_code& error, const std::size_t& bytes_transferred);
 
   AsyncTCPClient(AsyncTCPClient&); // block default copy constructor
 

--- a/include/sick_safetyscanners_base/communication/AsyncTCPClient.h
+++ b/include/sick_safetyscanners_base/communication/AsyncTCPClient.h
@@ -35,9 +35,6 @@
 #ifndef SICK_SAFETYSCANNERS_BASE_COMMUNICATION_ASYNCTCPCLIENT_H
 #define SICK_SAFETYSCANNERS_BASE_COMMUNICATION_ASYNCTCPCLIENT_H
 
-//#include <ros/ros.h>
-#include <sick_safetyscanners_base/logging/logging_wrapper.h>
-
 #include <functional>
 #include <iostream>
 #include <thread>

--- a/include/sick_safetyscanners_base/communication/AsyncUDPClient.h
+++ b/include/sick_safetyscanners_base/communication/AsyncUDPClient.h
@@ -35,9 +35,6 @@
 #ifndef SICK_SAFETYSCANNERS_BASE_COMMUNICATION_ASYNCUDPCLIENT_H
 #define SICK_SAFETYSCANNERS_BASE_COMMUNICATION_ASYNCUDPCLIENT_H
 
-//#include <ros/ros.h>
-#include <sick_safetyscanners_base/logging/logging_wrapper.h>
-
 #include <functional>
 #include <iostream>
 
@@ -63,6 +60,8 @@ public:
    */
   typedef boost::function<void(const sick::datastructure::PacketBuffer&)> PacketHandler;
 
+  typedef boost::asio::ip::udp::socket::endpoint_type endpoint_type;
+
   /*!
    * \brief Constructor of the asynchronous udp client.
    *
@@ -71,24 +70,33 @@ public:
    * \param local_port The local port, where the udp packets will arrive.
    */
   AsyncUDPClient(const PacketHandler& packet_handler,
-                 boost::asio::io_service& io_service,
-                 const uint16_t& local_port = 0);
+                 boost::asio::io_service& io_service );
 
   /*!
    * \brief The destructor of the asynchronous udp client.
    */
   virtual ~AsyncUDPClient();
 
+
+  /**
+   * \brief open
+   * \param local_port
+   * \return
+   */
+  boost::system::error_code open(const uint16_t& local_port = 0 );
+
   /*!
    * \brief Start the listening loop for the udp data packets.
    */
-  void runService();
+  void start();
+
+  void stop();
 
   /*!
-   * \brief Returns the actual port assigned to the local machine
-   * \return Local port number
+   * \brief Returns the actual enpoint settings of local machine
+   * \return The current local UDP endpoint settings
    */
-  unsigned short getLocalPort();
+  endpoint_type getLocalEndpoint() const;
 
 private:
   datastructure::PacketBuffer::ArrayBuffer m_recv_buffer;

--- a/include/sick_safetyscanners_base/communication/AsyncUDPClient.h
+++ b/include/sick_safetyscanners_base/communication/AsyncUDPClient.h
@@ -35,9 +35,6 @@
 #ifndef SICK_SAFETYSCANNERS_BASE_COMMUNICATION_ASYNCUDPCLIENT_H
 #define SICK_SAFETYSCANNERS_BASE_COMMUNICATION_ASYNCUDPCLIENT_H
 
-//#include <ros/ros.h>
-#include <sick_safetyscanners_base/logging/logging_wrapper.h>
-
 #include <functional>
 #include <iostream>
 

--- a/include/sick_safetyscanners_base/communication/AsyncUDPClient.h
+++ b/include/sick_safetyscanners_base/communication/AsyncUDPClient.h
@@ -79,7 +79,9 @@ public:
   /*!
    * \brief Start the listening loop for the udp data packets.
    */
-  void runService();
+  void start();
+
+  void stop();
 
   /*!
    * \brief Returns the actual port assigned to the local machine

--- a/include/sick_safetyscanners_base/communication/AsyncUDPClient.h
+++ b/include/sick_safetyscanners_base/communication/AsyncUDPClient.h
@@ -60,6 +60,8 @@ public:
    */
   typedef boost::function<void(const sick::datastructure::PacketBuffer&)> PacketHandler;
 
+  typedef boost::asio::ip::udp::socket::endpoint_type endpoint_type;
+
   /*!
    * \brief Constructor of the asynchronous udp client.
    *
@@ -68,13 +70,20 @@ public:
    * \param local_port The local port, where the udp packets will arrive.
    */
   AsyncUDPClient(const PacketHandler& packet_handler,
-                 boost::asio::io_service& io_service,
-                 const uint16_t& local_port = 0);
+                 boost::asio::io_service& io_service );
 
   /*!
    * \brief The destructor of the asynchronous udp client.
    */
   virtual ~AsyncUDPClient();
+
+
+  /**
+   * \brief open
+   * \param local_port
+   * \return
+   */
+  boost::system::error_code open(const uint16_t& local_port = 0 );
 
   /*!
    * \brief Start the listening loop for the udp data packets.
@@ -84,10 +93,10 @@ public:
   void stop();
 
   /*!
-   * \brief Returns the actual port assigned to the local machine
-   * \return Local port number
+   * \brief Returns the actual enpoint settings of local machine
+   * \return The current local UDP endpoint settings
    */
-  unsigned short getLocalPort();
+  endpoint_type getLocalEndpoint() const;
 
 private:
   datastructure::PacketBuffer::ArrayBuffer m_recv_buffer;

--- a/include/sick_safetyscanners_base/data_processing/ParseApplicationData.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseApplicationData.h
@@ -52,12 +52,13 @@ namespace data_processing {
  */
 class ParseApplicationData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseApplicationData();
 
+public:
   /*!
    * \brief Parses the application data from the packet buffer.
    *
@@ -66,90 +67,90 @@ public:
    *
    * \returns The parsed application data.
    */
-  datastructure::ApplicationData parseUDPSequence(const sick::datastructure::PacketBuffer& buffer,
-                                                  datastructure::Data& data) const;
+ static datastructure::ApplicationData parseUDPSequence(const sick::datastructure::PacketBuffer& buffer,
+                                                        datastructure::Data& data);
 
 private:
-  void setDataInApplicationData(std::vector<uint8_t>::const_iterator data_ptr,
-                                datastructure::ApplicationData& application_data) const;
-  void
+  static void setDataInApplicationData(std::vector<uint8_t>::const_iterator data_ptr,
+                                       datastructure::ApplicationData& application_data);
+  static void
   setApplicationInputsInApplicationData(std::vector<uint8_t>::const_iterator data_ptr,
-                                        datastructure::ApplicationData& application_data) const;
-  void
+                                        datastructure::ApplicationData& application_data);
+  static void
   setApplicationOutputsInApplicationData(std::vector<uint8_t>::const_iterator data_ptr,
-                                         datastructure::ApplicationData& application_data) const;
-  void setDataInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                  datastructure::ApplicationInputs& inputs) const;
-  void setDataInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                   datastructure::ApplicationOutputs& outputs) const;
-  void setUnsafeInputsInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                          datastructure::ApplicationInputs& inputs) const;
-  void setUnsafeInputsSourcesInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                                 datastructure::ApplicationInputs& inputs) const;
-  void setUnsafeInputsFlagsInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                               datastructure::ApplicationInputs& inputs) const;
-  void setMonitoringCaseInputsInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                                  datastructure::ApplicationInputs& inputs) const;
-  void setMonitoringCaseNumbersInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                                   datastructure::ApplicationInputs& inputs) const;
-  void setMonitoringCaseFlagsInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                                 datastructure::ApplicationInputs& inputs) const;
-  void setLinearVelocityInputsInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                                  datastructure::ApplicationInputs& inputs) const;
-  void setLinearVelocity0InApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                             datastructure::ApplicationInputs& inputs) const;
-  void setLinearVelocity1InApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                             datastructure::ApplicationInputs& inputs) const;
-  void setLinearVelocityFlagsInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                                 datastructure::ApplicationInputs& inputs) const;
-  void setSleepModeInputInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                            datastructure::ApplicationInputs& inputs) const;
-  void
+                                         datastructure::ApplicationData& application_data);
+  static void setDataInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                         datastructure::ApplicationInputs& inputs);
+  static void setDataInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                          datastructure::ApplicationOutputs& outputs);
+  static void setUnsafeInputsInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                 datastructure::ApplicationInputs& inputs);
+  static void setUnsafeInputsSourcesInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                        datastructure::ApplicationInputs& inputs);
+  static void setUnsafeInputsFlagsInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                      datastructure::ApplicationInputs& inputs);
+  static void setMonitoringCaseInputsInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                         datastructure::ApplicationInputs& inputs);
+  static void setMonitoringCaseNumbersInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                          datastructure::ApplicationInputs& inputs);
+  static void setMonitoringCaseFlagsInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                        datastructure::ApplicationInputs& inputs);
+  static void setLinearVelocityInputsInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                         datastructure::ApplicationInputs& inputs);
+  static void setLinearVelocity0InApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                    datastructure::ApplicationInputs& inputs);
+  static void setLinearVelocity1InApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                    datastructure::ApplicationInputs& inputs);
+  static void setLinearVelocityFlagsInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                        datastructure::ApplicationInputs& inputs);
+  static void setSleepModeInputInApplicationInputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                   datastructure::ApplicationInputs& inputs);
+  static void
   setEvalutaionPathsOutputsInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                                datastructure::ApplicationOutputs& outputs) const;
-  void setEvaluationPathsOutputsEvalOutInApplicationOutputs(
+                                                datastructure::ApplicationOutputs& outputs);
+  static void setEvaluationPathsOutputsEvalOutInApplicationOutputs(
     std::vector<uint8_t>::const_iterator data_ptr,
-    datastructure::ApplicationOutputs& outputs) const;
-  void setEvaluationPathsOutputsIsSafeInApplicationOutputs(
+    datastructure::ApplicationOutputs& outputs);
+  static void setEvaluationPathsOutputsIsSafeInApplicationOutputs(
     std::vector<uint8_t>::const_iterator data_ptr,
-    datastructure::ApplicationOutputs& outputs) const;
-  void setEvaluationPathsOutputsValidFlagsInApplicationOutputs(
+    datastructure::ApplicationOutputs& outputs);
+  static void setEvaluationPathsOutputsValidFlagsInApplicationOutputs(
     std::vector<uint8_t>::const_iterator data_ptr,
-    datastructure::ApplicationOutputs& outputs) const;
-  void
+    datastructure::ApplicationOutputs& outputs);
+  static void
   setMonitoringCaseOutputsInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                               datastructure::ApplicationOutputs& outputs) const;
-  void
+                                               datastructure::ApplicationOutputs& outputs);
+  static void
   setMonitoringCaseNumbersInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                               datastructure::ApplicationOutputs& outputs) const;
-  void setMonitoringCaseFlagsInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                                  datastructure::ApplicationOutputs& outputs) const;
-  void setSleepModeOutputInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                              datastructure::ApplicationOutputs& outputs) const;
-  void setErrorFlagsInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                         datastructure::ApplicationOutputs& outputs) const;
-  void
+                                               datastructure::ApplicationOutputs& outputs);
+  static void setMonitoringCaseFlagsInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                         datastructure::ApplicationOutputs& outputs);
+  static void setSleepModeOutputInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                     datastructure::ApplicationOutputs& outputs);
+  static void setErrorFlagsInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                datastructure::ApplicationOutputs& outputs);
+  static void
   setLinearVelocityOutoutsInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                               datastructure::ApplicationOutputs& outputs) const;
-  void setLinearVelocity0InApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                              datastructure::ApplicationOutputs& outputs) const;
-  void setLinearVelocity1InApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                              datastructure::ApplicationOutputs& outputs) const;
-  void setLinearVelocityFlagsInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                                  datastructure::ApplicationOutputs& outputs) const;
-  void
+                                               datastructure::ApplicationOutputs& outputs);
+  static void setLinearVelocity0InApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                     datastructure::ApplicationOutputs& outputs);
+  static void setLinearVelocity1InApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                     datastructure::ApplicationOutputs& outputs);
+  static void setLinearVelocityFlagsInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                         datastructure::ApplicationOutputs& outputs);
+  static void
   setResultingVelocityOutputsInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                                  datastructure::ApplicationOutputs& outputs) const;
-  void setResultingVelocityInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                                datastructure::ApplicationOutputs& outputs) const;
-  void
+                                                  datastructure::ApplicationOutputs& outputs);
+  static void setResultingVelocityInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
+                                                       datastructure::ApplicationOutputs& outputs);
+  static void
   setResultingVelocityFlagsInApplicationOutputs(std::vector<uint8_t>::const_iterator data_ptr,
-                                                datastructure::ApplicationOutputs& outputs) const;
-  void setOutputFlagsinApplicationOutput(std::vector<uint8_t>::const_iterator data_ptr,
-                                         datastructure::ApplicationOutputs& outputs) const;
-  bool checkIfPreconditionsAreMet(const datastructure::Data& data) const;
-  bool checkIfApplicationDataIsPublished(const datastructure::Data& data) const;
-  bool checkIfDataContainsNeededParsedBlocks(const datastructure::Data& data) const;
+                                                datastructure::ApplicationOutputs& outputs);
+  static void setOutputFlagsinApplicationOutput(std::vector<uint8_t>::const_iterator data_ptr,
+                                                datastructure::ApplicationOutputs& outputs);
+  static bool checkIfPreconditionsAreMet(const datastructure::Data& data);
+  static bool checkIfApplicationDataIsPublished(const datastructure::Data& data);
+  static bool checkIfDataContainsNeededParsedBlocks(const datastructure::Data& data);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseApplicationNameData.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseApplicationNameData.h
@@ -51,12 +51,13 @@ namespace data_processing {
  */
 class ParseApplicationNameData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseApplicationNameData();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the type code of the sensor.
    *
@@ -65,16 +66,16 @@ public:
    *
    * \returns If parsing was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::ApplicationName& application_name) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                              datastructure::ApplicationName& application_name);
 
 private:
-  std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readNameLength(std::vector<uint8_t>::const_iterator data_ptr) const;
-  std::string readApplicationName(std::vector<uint8_t>::const_iterator data_ptr) const;
+  static std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readNameLength(std::vector<uint8_t>::const_iterator data_ptr);
+  static std::string readApplicationName(std::vector<uint8_t>::const_iterator data_ptr);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseConfigMetadata.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseConfigMetadata.h
@@ -51,12 +51,13 @@ namespace data_processing {
  */
 class ParseConfigMetadata
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseConfigMetadata();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the type code of the sensor.
    *
@@ -65,21 +66,21 @@ public:
    *
    * \returns If parsing was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::ConfigMetadata& config_metadata) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               datastructure::ConfigMetadata& config_metadata);
 
 private:
-  std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readModificationTimeDate(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readModificationTimeTime(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readTransferTimeDate(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readTransferTimeTime(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readAppChecksum(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readOverallChecksum(std::vector<uint8_t>::const_iterator data_ptr) const;
-  std::vector<uint32_t> readIntegrityHash(std::vector<uint8_t>::const_iterator data_ptr) const;
+  static std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readModificationTimeDate(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readModificationTimeTime(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readTransferTimeDate(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readTransferTimeTime(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readAppChecksum(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readOverallChecksum(std::vector<uint8_t>::const_iterator data_ptr);
+  static std::vector<uint32_t> readIntegrityHash(std::vector<uint8_t>::const_iterator data_ptr);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseData.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseData.h
@@ -55,12 +55,13 @@ namespace data_processing {
  */
 class ParseData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseData();
 
+public:
   /*!
    * \brief Parses the udp data transferred in the packet buffer. It will be parsed into the data
    * reference.
@@ -69,33 +70,26 @@ public:
    *
    * \returns Parsed data
    */
-  sick::datastructure::Data parseUDPSequence(const sick::datastructure::PacketBuffer& buffer) const;
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        sick::datastructure::Data& data) const;
+  static sick::datastructure::Data parseUDPSequence(const sick::datastructure::PacketBuffer& buffer);
+
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               sick::datastructure::Data& data);
 
 private:
-  std::shared_ptr<sick::data_processing::ParseDataHeader> m_data_header_parser_ptr;
-  std::shared_ptr<sick::data_processing::ParseDerivedValues> m_derived_values_parser_ptr;
-  std::shared_ptr<sick::data_processing::ParseMeasurementData> m_measurement_data_parser_ptr;
-  std::shared_ptr<sick::data_processing::ParseGeneralSystemState> m_general_system_state_parser_ptr;
-  std::shared_ptr<sick::data_processing::ParseIntrusionData> m_intrusion_data_parser_ptr;
-  std::shared_ptr<sick::data_processing::ParseApplicationData> m_application_data_parser_ptr;
-
-
-  void setDataBlocksInData(const datastructure::PacketBuffer& buffer,
-                           datastructure::Data& data) const;
-  void setDataHeaderInData(const datastructure::PacketBuffer& buffer,
-                           datastructure::Data& data) const;
-  void setDerivedValuesInData(const datastructure::PacketBuffer& buffer,
-                              datastructure::Data& data) const;
-  void setMeasurementDataInData(const datastructure::PacketBuffer& buffer,
-                                datastructure::Data& data) const;
-  void setGeneralSystemStateInData(const datastructure::PacketBuffer& buffer,
-                                   datastructure::Data& data) const;
-  void setIntrusionDataInData(const datastructure::PacketBuffer& buffer,
-                              datastructure::Data& data) const;
-  void setApplicationDataInData(const datastructure::PacketBuffer& buffer,
-                                datastructure::Data& data) const;
+  static void setDataBlocksInData(const datastructure::PacketBuffer& buffer,
+                                  datastructure::Data& data);
+  static void setDataHeaderInData(const datastructure::PacketBuffer& buffer,
+                                  datastructure::Data& data);
+  static void setDerivedValuesInData(const datastructure::PacketBuffer& buffer,
+                                     datastructure::Data& data);
+  static void setMeasurementDataInData(const datastructure::PacketBuffer& buffer,
+                                       datastructure::Data& data);
+  static void setGeneralSystemStateInData(const datastructure::PacketBuffer& buffer,
+                                          datastructure::Data& data);
+  static void setIntrusionDataInData(const datastructure::PacketBuffer& buffer,
+                                     datastructure::Data& data);
+  static void setApplicationDataInData(const datastructure::PacketBuffer& buffer,
+                                       datastructure::Data& data);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseData.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseData.h
@@ -55,12 +55,13 @@ namespace data_processing {
  */
 class ParseData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseData();
 
+public:
   /*!
    * \brief Parses the udp data transferred in the packet buffer. It will be parsed into the data
    * reference.
@@ -69,31 +70,23 @@ public:
    *
    * \returns Parsed data
    */
-  sick::datastructure::Data parseUDPSequence(const sick::datastructure::PacketBuffer& buffer) const;
+  static sick::datastructure::Data parseUDPSequence(const sick::datastructure::PacketBuffer& buffer);
 
 private:
-  std::shared_ptr<sick::data_processing::ParseDataHeader> m_data_header_parser_ptr;
-  std::shared_ptr<sick::data_processing::ParseDerivedValues> m_derived_values_parser_ptr;
-  std::shared_ptr<sick::data_processing::ParseMeasurementData> m_measurement_data_parser_ptr;
-  std::shared_ptr<sick::data_processing::ParseGeneralSystemState> m_general_system_state_parser_ptr;
-  std::shared_ptr<sick::data_processing::ParseIntrusionData> m_intrusion_data_parser_ptr;
-  std::shared_ptr<sick::data_processing::ParseApplicationData> m_application_data_parser_ptr;
-
-
-  void setDataBlocksInData(const datastructure::PacketBuffer& buffer,
-                           datastructure::Data& data) const;
-  void setDataHeaderInData(const datastructure::PacketBuffer& buffer,
-                           datastructure::Data& data) const;
-  void setDerivedValuesInData(const datastructure::PacketBuffer& buffer,
-                              datastructure::Data& data) const;
-  void setMeasurementDataInData(const datastructure::PacketBuffer& buffer,
-                                datastructure::Data& data) const;
-  void setGeneralSystemStateInData(const datastructure::PacketBuffer& buffer,
-                                   datastructure::Data& data) const;
-  void setIntrusionDataInData(const datastructure::PacketBuffer& buffer,
-                              datastructure::Data& data) const;
-  void setApplicationDataInData(const datastructure::PacketBuffer& buffer,
-                                datastructure::Data& data) const;
+  static void setDataBlocksInData(const datastructure::PacketBuffer& buffer,
+                                  datastructure::Data& data);
+  static void setDataHeaderInData(const datastructure::PacketBuffer& buffer,
+                                  datastructure::Data& data);
+  static void setDerivedValuesInData(const datastructure::PacketBuffer& buffer,
+                                     datastructure::Data& data);
+  static void setMeasurementDataInData(const datastructure::PacketBuffer& buffer,
+                                       datastructure::Data& data);
+  static void setGeneralSystemStateInData(const datastructure::PacketBuffer& buffer,
+                                          datastructure::Data& data);
+  static void setIntrusionDataInData(const datastructure::PacketBuffer& buffer,
+                                     datastructure::Data& data);
+  static void setApplicationDataInData(const datastructure::PacketBuffer& buffer,
+                                       datastructure::Data& data);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseDataHeader.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseDataHeader.h
@@ -53,12 +53,13 @@ namespace data_processing {
  */
 class ParseDataHeader
 {
-public:
+private:
   /*!
    * \brief  Constructor of the parser.
    */
   ParseDataHeader();
 
+public:
   /*!
    * \brief Parses the data header from a udp sequence.
    *
@@ -67,60 +68,60 @@ public:
    *
    * \returns The parsed data header.
    */
-  datastructure::DataHeader parseUDPSequence(const datastructure::PacketBuffer& buffer,
-                                             datastructure::Data& data) const;
+  static datastructure::DataHeader parseUDPSequence(const datastructure::PacketBuffer& buffer,
+                                                    datastructure::Data& data);
 
 private:
-  void setVersionIndicatorInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                       datastructure::DataHeader& data_header) const;
-  void setMajorVersionInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                   datastructure::DataHeader& data_header) const;
-  void setMinorVersionInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                   datastructure::DataHeader& data_header) const;
-  void setVersionReleaseInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                     datastructure::DataHeader& data_header) const;
-  void setSerialNumberOfDeviceInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                           datastructure::DataHeader& data_header) const;
-  void setSerialNumberOfSystemPlugInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                               datastructure::DataHeader& data_header) const;
-  void setChannelNumberInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                    datastructure::DataHeader& data_header) const;
-  void setSequenceNumberInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                     datastructure::DataHeader& data_header) const;
-  void setScanNumberInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                 datastructure::DataHeader& data_header) const;
-  void setTimestampDateInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                    datastructure::DataHeader& data_header) const;
-  void setTimestampTimeInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                    datastructure::DataHeader& data_header) const;
-  void setGeneralSystemStateBlockOffsetInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                    datastructure::DataHeader& data_header) const;
-  void setGeneralSystemStateBlockSizeInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                  datastructure::DataHeader& data_header) const;
-  void setDerivedValuesBlockOffsetInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                               datastructure::DataHeader& data_header) const;
-  void setDerivedValuesBlockSizeInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                             datastructure::DataHeader& data_header) const;
-  void setMeasurementDataBlockOffsetInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                 datastructure::DataHeader& data_header) const;
-  void setMeasurementDataBlockSizeInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                               datastructure::DataHeader& data_header) const;
-  void setIntrusionDataBlockOffsetInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                               datastructure::DataHeader& data_header) const;
-  void setIntrusionDataBlockSizeInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                             datastructure::DataHeader& data_header) const;
-  void setApplicationDataBlockOffsetInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                 datastructure::DataHeader& data_header) const;
-  void setApplicationDataBlockSizeInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                               datastructure::DataHeader& data_header) const;
-  void setDataInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                           datastructure::DataHeader& data_header) const;
-  void setVersionInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                              datastructure::DataHeader& data_header) const;
-  void setScanHeaderInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                 datastructure::DataHeader& data_header) const;
-  void setDataBlocksInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                 datastructure::DataHeader& data_header) const;
+  static void setVersionIndicatorInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                              datastructure::DataHeader& data_header);
+  static void setMajorVersionInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                          datastructure::DataHeader& data_header);
+  static void setMinorVersionInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                          datastructure::DataHeader& data_header);
+  static void setVersionReleaseInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                            datastructure::DataHeader& data_header);
+  static void setSerialNumberOfDeviceInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                                  datastructure::DataHeader& data_header);
+  static void setSerialNumberOfSystemPlugInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                                      datastructure::DataHeader& data_header);
+  static void setChannelNumberInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                           datastructure::DataHeader& data_header);
+  static void setSequenceNumberInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                            datastructure::DataHeader& data_header);
+  static void setScanNumberInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                        datastructure::DataHeader& data_header);
+  static void setTimestampDateInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                           datastructure::DataHeader& data_header);
+  static void setTimestampTimeInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                           datastructure::DataHeader& data_header);
+  static void setGeneralSystemStateBlockOffsetInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                                           datastructure::DataHeader& data_header);
+  static void setGeneralSystemStateBlockSizeInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                                         datastructure::DataHeader& data_header);
+  static void setDerivedValuesBlockOffsetInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                                      datastructure::DataHeader& data_header);
+  static void setDerivedValuesBlockSizeInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                                    datastructure::DataHeader& data_header);
+  static void setMeasurementDataBlockOffsetInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                                        datastructure::DataHeader& data_header);
+  static void setMeasurementDataBlockSizeInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                                      datastructure::DataHeader& data_header);
+  static void setIntrusionDataBlockOffsetInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                                      datastructure::DataHeader& data_header);
+  static void setIntrusionDataBlockSizeInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                                    datastructure::DataHeader& data_header);
+  static void setApplicationDataBlockOffsetInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                                        datastructure::DataHeader& data_header);
+  static void setApplicationDataBlockSizeInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                                      datastructure::DataHeader& data_header);
+  static void setDataInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                  datastructure::DataHeader& data_header);
+  static void setVersionInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                     datastructure::DataHeader& data_header);
+  static void setScanHeaderInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                        datastructure::DataHeader& data_header);
+  static void setDataBlocksInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                        datastructure::DataHeader& data_header);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseDatagramHeader.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseDatagramHeader.h
@@ -52,12 +52,13 @@ namespace data_processing {
  */
 class ParseDatagramHeader
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseDatagramHeader();
 
+public:
   /*!
    * \brief Parses the udp sequence to get the identification and the offset for the datagram
    * header.
@@ -67,27 +68,27 @@ public:
    *
    * \returns If parsing the datagram header was successful.
    */
-  bool parseUDPSequence(const datastructure::PacketBuffer& buffer,
-                        sick::datastructure::DatagramHeader& header) const;
+  static bool parseUDPSequence(const datastructure::PacketBuffer& buffer,
+                               sick::datastructure::DatagramHeader& header);
 
 private:
-  void setDataInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                       datastructure::DatagramHeader& header) const;
+  static void setDataInHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                              datastructure::DatagramHeader& header);
 
-  void setDatagramMarkerInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                 datastructure::DatagramHeader& header) const;
-  void setProtocolInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                           datastructure::DatagramHeader& header) const;
-  void setMajorVersionInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                               datastructure::DatagramHeader& header) const;
-  void setMinorVersionInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                               datastructure::DatagramHeader& header) const;
-  void setTotalLengthInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                              datastructure::DatagramHeader& header) const;
-  void setIdentificationInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                 datastructure::DatagramHeader& header) const;
-  void setFragmentOffsetInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                 datastructure::DatagramHeader& header) const;
+  static void setDatagramMarkerInHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                        datastructure::DatagramHeader& header);
+  static void setProtocolInHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                  datastructure::DatagramHeader& header);
+  static void setMajorVersionInHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                      datastructure::DatagramHeader& header);
+  static void setMinorVersionInHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                      datastructure::DatagramHeader& header);
+  static void setTotalLengthInHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                     datastructure::DatagramHeader& header);
+  static void setIdentificationInHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                        datastructure::DatagramHeader& header);
+  static void setFragmentOffsetInHeader(std::vector<uint8_t>::const_iterator data_ptr,
+                                        datastructure::DatagramHeader& header);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseDerivedValues.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseDerivedValues.h
@@ -49,12 +49,13 @@ namespace data_processing {
  */
 class ParseDerivedValues
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseDerivedValues();
 
+public:
   /*!
    * \brief Parsed the packet buffer and returns the derived values.
    *
@@ -63,27 +64,27 @@ public:
    *
    * \returns The parsed derived values.
    */
-  datastructure::DerivedValues parseUDPSequence(const datastructure::PacketBuffer& buffer,
-                                                datastructure::Data& data) const;
+  static datastructure::DerivedValues parseUDPSequence(const datastructure::PacketBuffer& buffer,
+                                                       datastructure::Data& data);
 
 private:
-  void setDataInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
-                              datastructure::DerivedValues& derived_values) const;
-  void setMultiplicationFactorInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
-                                              datastructure::DerivedValues& derived_values) const;
-  void setNumberOfBeamsInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
-                                       datastructure::DerivedValues& derived_values) const;
-  void setScanTimeInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
-                                  datastructure::DerivedValues& derived_values) const;
-  void setStartAngleInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
-                                    datastructure::DerivedValues& derived_values) const;
-  void setAngularBeamResolutionInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
-                                               datastructure::DerivedValues& derived_values) const;
-  void setInterbeamPeriodInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
-                                         datastructure::DerivedValues& derived_values) const;
-  bool checkIfPreconditionsAreMet(const datastructure::Data& data) const;
-  bool checkIfDerivedValuesIsPublished(const datastructure::Data& data) const;
-  bool checkIfDataContainsNeededParsedBlocks(const datastructure::Data& data) const;
+  static void setDataInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
+                                     datastructure::DerivedValues& derived_values);
+  static void setMultiplicationFactorInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
+                                                     datastructure::DerivedValues& derived_values);
+  static void setNumberOfBeamsInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
+                                              datastructure::DerivedValues& derived_values);
+  static void setScanTimeInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
+                                         datastructure::DerivedValues& derived_values);
+  static void setStartAngleInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
+                                           datastructure::DerivedValues& derived_values);
+  static void setAngularBeamResolutionInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
+                                                      datastructure::DerivedValues& derived_values);
+  static void setInterbeamPeriodInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
+                                                datastructure::DerivedValues& derived_values);
+  static bool checkIfPreconditionsAreMet(const datastructure::Data& data);
+  static bool checkIfDerivedValuesIsPublished(const datastructure::Data& data);
+  static bool checkIfDataContainsNeededParsedBlocks(const datastructure::Data& data);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseDeviceName.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseDeviceName.h
@@ -53,12 +53,13 @@ namespace data_processing {
  */
 class ParseDeviceName
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseDeviceName();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the device name of the sensor.
    *
@@ -67,11 +68,11 @@ public:
    *
    * \returns If parsing the device name was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::DeviceName& device_name) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               datastructure::DeviceName& device_name);
 
 private:
-  std::string readDeviceName(std::vector<uint8_t>::const_iterator data_ptr) const;
+  static std::string readDeviceName(std::vector<uint8_t>::const_iterator data_ptr);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseDeviceStatus.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseDeviceStatus.h
@@ -51,12 +51,13 @@ namespace data_processing {
  */
 class ParseDeviceStatusData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseDeviceStatusData();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the device status of the sensor.
    *
@@ -65,11 +66,11 @@ public:
    *
    * \returns If parsing was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::DeviceStatus& device_status) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               datastructure::DeviceStatus& device_status);
 
 private:
-  uint8_t readDeviceStatus(std::vector<uint8_t>::const_iterator data_ptr) const;
+  static uint8_t readDeviceStatus(std::vector<uint8_t>::const_iterator data_ptr);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseFieldGeometryData.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseFieldGeometryData.h
@@ -53,12 +53,13 @@ namespace data_processing {
  */
 class ParseFieldGeometryData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseFieldGeometryData();
 
+public:
   /*!
    * \brief Parses a tcp sequence and return the field geometry data of the warning and protective
    * fields.
@@ -68,13 +69,13 @@ public:
    *
    * \returns If parsing the sequence was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::FieldData& field_data) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               datastructure::FieldData& field_data);
 
 private:
-  uint32_t readArrayLength(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readArrayElement(std::vector<uint8_t>::const_iterator data_ptr,
-                            uint32_t elem_number) const;
+  static uint32_t readArrayLength(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readArrayElement(std::vector<uint8_t>::const_iterator data_ptr,
+                                   uint32_t elem_number);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseFieldHeaderData.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseFieldHeaderData.h
@@ -51,12 +51,13 @@ namespace data_processing {
  */
 class ParseFieldHeaderData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseFieldHeaderData();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the header for a warning or protective field.
    *
@@ -65,25 +66,25 @@ public:
    *
    * \returns If parsing was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::FieldData& field_data) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                        datastructure::FieldData& field_data);
 
 private:
-  bool isValid(std::vector<uint8_t>::const_iterator data_ptr) const;
-  void setFieldType(std::vector<uint8_t>::const_iterator data_ptr,
-                    datastructure::FieldData& field_data) const;
-  uint8_t readFieldType(std::vector<uint8_t>::const_iterator data_ptr) const;
-  std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  bool readIsDefined(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readEvalMethod(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readMultiSampling(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readObjectResolution(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readSetIndex(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readNameLength(std::vector<uint8_t>::const_iterator data_ptr) const;
-  std::string readFieldName(std::vector<uint8_t>::const_iterator data_ptr) const;
+  static bool isValid(std::vector<uint8_t>::const_iterator data_ptr);
+  static void setFieldType(std::vector<uint8_t>::const_iterator data_ptr,
+                    datastructure::FieldData& field_data);
+  static uint8_t readFieldType(std::vector<uint8_t>::const_iterator data_ptr);
+  static std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static bool readIsDefined(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readEvalMethod(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readMultiSampling(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readObjectResolution(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readSetIndex(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readNameLength(std::vector<uint8_t>::const_iterator data_ptr);
+  static std::string readFieldName(std::vector<uint8_t>::const_iterator data_ptr);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseFieldSetsData.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseFieldSetsData.h
@@ -51,12 +51,13 @@ namespace data_processing {
  */
 class ParseFieldSetsData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseFieldSetsData();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the field sets of the sensor.
    *
@@ -65,21 +66,21 @@ public:
    *
    * \returns If parsing was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::FieldSets& field_sets) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               datastructure::FieldSets& field_sets);
 
 private:
-  std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readArrayLength(std::vector<uint8_t>::const_iterator data_ptr) const;
-  std::vector<uint32_t> readNameLength(std::vector<uint8_t>::const_iterator data_ptr,
-                                       uint32_t array_length) const;
-  std::vector<std::string> readFieldName(std::vector<uint8_t>::const_iterator data_ptr,
-                                         uint32_t array_length) const;
-  std::vector<bool> readIsDefined(std::vector<uint8_t>::const_iterator data_ptr,
-                                  uint32_t array_length) const;
+  static std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readArrayLength(std::vector<uint8_t>::const_iterator data_ptr);
+  static std::vector<uint32_t> readNameLength(std::vector<uint8_t>::const_iterator data_ptr,
+                                              uint32_t array_length);
+  static std::vector<std::string> readFieldName(std::vector<uint8_t>::const_iterator data_ptr,
+                                                uint32_t array_length);
+  static std::vector<bool> readIsDefined(std::vector<uint8_t>::const_iterator data_ptr,
+                                         uint32_t array_length);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseFirmwareVersion.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseFirmwareVersion.h
@@ -53,12 +53,13 @@ namespace data_processing {
  */
 class ParseFirmwareVersion
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseFirmwareVersion();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the firmware version of the sensor.
    *
@@ -67,10 +68,10 @@ public:
    *
    * \returns If parsing the firmware version was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::FirmwareVersion& firmware_version) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               datastructure::FirmwareVersion& firmware_version);
 
-  std::string readFirmwareVersion(std::vector<uint8_t>::const_iterator data_ptr) const;
+  static std::string readFirmwareVersion(std::vector<uint8_t>::const_iterator data_ptr);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseGeneralSystemState.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseGeneralSystemState.h
@@ -51,12 +51,13 @@ namespace data_processing {
  */
 class ParseGeneralSystemState
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseGeneralSystemState();
 
+public:
   /*!
    * \brief Parses the udp sequence to read the general system state if enabled.
    *
@@ -65,33 +66,33 @@ public:
    *
    * \returns If parsing was successful.
    */
-  datastructure::GeneralSystemState
+  static datastructure::GeneralSystemState
   parseUDPSequence(const sick::datastructure::PacketBuffer& buffer,
-                   datastructure::Data& data) const;
+                   datastructure::Data& data);
 
 private:
-  void setDataInGeneralSystemState(std::vector<uint8_t>::const_iterator data_ptr,
-                                   datastructure::GeneralSystemState& general_system_state) const;
-  void
+  static void setDataInGeneralSystemState(std::vector<uint8_t>::const_iterator data_ptr,
+                                   datastructure::GeneralSystemState& general_system_state);
+  static void
   setStatusBitsInGeneralSystemState(std::vector<uint8_t>::const_iterator data_ptr,
-                                    datastructure::GeneralSystemState& general_system_state) const;
-  void setSafeCutOffPathInGeneralSystemState(
+                                    datastructure::GeneralSystemState& general_system_state);
+  static void setSafeCutOffPathInGeneralSystemState(
     std::vector<uint8_t>::const_iterator data_ptr,
-    datastructure::GeneralSystemState& general_system_state) const;
-  void setNonSafeCutOffPathInGeneralSystemState(
+    datastructure::GeneralSystemState& general_system_state);
+  static void setNonSafeCutOffPathInGeneralSystemState(
     std::vector<uint8_t>::const_iterator data_ptr,
-    datastructure::GeneralSystemState& general_system_state) const;
-  void setResetRequiredCutOffPathInGeneralSystemState(
+    datastructure::GeneralSystemState& general_system_state);
+  static void setResetRequiredCutOffPathInGeneralSystemState(
     std::vector<uint8_t>::const_iterator data_ptr,
-    datastructure::GeneralSystemState& general_system_state) const;
-  void setCurrentMonitoringCasesInGeneralSystemState(
+    datastructure::GeneralSystemState& general_system_state);
+  static void setCurrentMonitoringCasesInGeneralSystemState(
     std::vector<uint8_t>::const_iterator data_ptr,
-    datastructure::GeneralSystemState& general_system_state) const;
-  void setErrorsInGeneralSystemState(std::vector<uint8_t>::const_iterator data_ptr,
-                                     datastructure::GeneralSystemState& general_system_state) const;
-  bool checkIfPreconditionsAreMet(const datastructure::Data& data) const;
-  bool checkIfGeneralSystemStateIsPublished(const datastructure::Data& data) const;
-  bool checkIfDataContainsNeededParsedBlocks(const datastructure::Data& data) const;
+    datastructure::GeneralSystemState& general_system_state);
+  static void setErrorsInGeneralSystemState(std::vector<uint8_t>::const_iterator data_ptr,
+                                     datastructure::GeneralSystemState& general_system_state);
+  static bool checkIfPreconditionsAreMet(const datastructure::Data& data);
+  static bool checkIfGeneralSystemStateIsPublished(const datastructure::Data& data);
+  static bool checkIfDataContainsNeededParsedBlocks(const datastructure::Data& data);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseIntrusionData.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseIntrusionData.h
@@ -51,12 +51,13 @@ namespace data_processing {
  */
 class ParseIntrusionData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseIntrusionData();
 
+public:
   /*!
    * \brief Parse a udp sequence to read the intrusion data if enabled.
    *
@@ -65,28 +66,27 @@ public:
    *
    * \returns The parsed intrusion data.
    */
-  datastructure::IntrusionData parseUDPSequence(const datastructure::PacketBuffer& buffer,
-                                                datastructure::Data& data);
-  uint16_t getNumScanPoints() const;
-  void setNumScanPoints(const uint16_t& num_scan_points);
+  static datastructure::IntrusionData parseUDPSequence(const datastructure::PacketBuffer& buffer,
+                                                       datastructure::Data& data);
 
 private:
-  uint16_t m_num_scan_points;
-
-  void setDataInIntrusionData(std::vector<uint8_t>::const_iterator data_ptr,
-                              datastructure::IntrusionData& intrusion_data) const;
-  void setDataInIntrusionDatums(
-    std::vector<uint8_t>::const_iterator data_ptr,
-    std::vector<sick::datastructure::IntrusionDatum>& intrusion_datums) const;
-  uint16_t setSizeInIntrusionDatum(const uint16_t& offset,
-                                   std::vector<uint8_t>::const_iterator data_ptr,
-                                   sick::datastructure::IntrusionDatum& datum) const;
-  uint16_t setFlagsInIntrusionDatum(const uint16_t& offset,
-                                    std::vector<uint8_t>::const_iterator data_ptr,
-                                    sick::datastructure::IntrusionDatum& datum) const;
-  bool checkIfPreconditionsAreMet(const datastructure::Data& data) const;
-  bool checkIfIntrusionDataIsPublished(const datastructure::Data& data) const;
-  bool checkIfDataContainsNeededParsedBlocks(const datastructure::Data& data) const;
+  static void setDataInIntrusionData(const uint16_t num_scan_points,
+                                     std::vector<uint8_t>::const_iterator data_ptr,
+                                     datastructure::IntrusionData& intrusion_data);
+  static void setDataInIntrusionDatums(
+      uint16_t num_scan_points,
+      std::vector<uint8_t>::const_iterator data_ptr,
+      std::vector<sick::datastructure::IntrusionDatum>& intrusion_datums);
+  static uint16_t setSizeInIntrusionDatum(const uint16_t& offset,
+                                          std::vector<uint8_t>::const_iterator data_ptr,
+                                          sick::datastructure::IntrusionDatum& datum);
+  static uint16_t setFlagsInIntrusionDatum(const uint16_t offset,
+                                           const uint16_t num_scan_points,
+                                           std::vector<uint8_t>::const_iterator data_ptr,
+                                           sick::datastructure::IntrusionDatum& datum);
+  static bool checkIfPreconditionsAreMet(const datastructure::Data& data);
+  static bool checkIfIntrusionDataIsPublished(const datastructure::Data& data);
+  static bool checkIfDataContainsNeededParsedBlocks(const datastructure::Data& data);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseMeasurementCurrentConfigData.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseMeasurementCurrentConfigData.h
@@ -52,12 +52,13 @@ namespace data_processing {
  */
 class ParseMeasurementCurrentConfigData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseMeasurementCurrentConfigData();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the current configuration of the sensor.
    *
@@ -66,28 +67,28 @@ public:
    *
    * \returns If parsing was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::ConfigData& config_data) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                        datastructure::ConfigData& config_data);
 
 private:
-  std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  bool readEnabled(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readInterfaceType(std::vector<uint8_t>::const_iterator data_ptr) const;
-  boost::asio::ip::address_v4 readHostIp(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readHostPort(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readPublishingFreq(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readEndAngle(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readStartAngle(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readFeatures(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readDerivedMultiplicationFactor(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readDerivedNumBeams(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readDerivedScanTime(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readDerivedStartAngle(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readDerivedAngularBeamResolution(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readDerivedInterbeamPeriod(std::vector<uint8_t>::const_iterator data_ptr) const;
+  static std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static bool readEnabled(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readInterfaceType(std::vector<uint8_t>::const_iterator data_ptr);
+  static boost::asio::ip::address_v4 readHostIp(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readHostPort(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readPublishingFreq(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readEndAngle(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readStartAngle(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readFeatures(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readDerivedMultiplicationFactor(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readDerivedNumBeams(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readDerivedScanTime(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readDerivedStartAngle(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readDerivedAngularBeamResolution(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readDerivedInterbeamPeriod(std::vector<uint8_t>::const_iterator data_ptr);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseMeasurementData.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseMeasurementData.h
@@ -52,12 +52,13 @@ namespace data_processing {
  */
 class ParseMeasurementData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseMeasurementData();
 
+public:
   /*!
    * \brief Parses the measurement data if it is enabled.
    *
@@ -66,25 +67,27 @@ public:
    *
    * \returns The parsed measurement data.
    */
-  datastructure::MeasurementData parseUDPSequence(const datastructure::PacketBuffer& buffer,
-                                                  datastructure::Data& data);
+  static datastructure::MeasurementData parseUDPSequence(const datastructure::PacketBuffer& buffer,
+                                                         datastructure::Data& data);
 
 private:
-  float m_angle;
-  float m_angle_delta;
-  void setDataInMeasurementData(std::vector<uint8_t>::const_iterator data_ptr,
-                                datastructure::MeasurementData& measurement_data);
-  void setNumberOfBeamsInMeasurementData(std::vector<uint8_t>::const_iterator data_ptr,
-                                         datastructure::MeasurementData& measurement_data) const;
-  void setStartAngleAndDelta(const datastructure::Data& data);
-  void setScanPointsInMeasurementData(std::vector<uint8_t>::const_iterator data_ptr,
-                                      datastructure::MeasurementData& measurement_data);
-  void addScanPointToMeasurementData(uint16_t offset,
-                                     std::vector<uint8_t>::const_iterator data_ptr,
-                                     datastructure::MeasurementData& measurement_data) const;
-  bool checkIfPreconditionsAreMet(const datastructure::Data& data) const;
-  bool checkIfMeasurementDataIsPublished(const datastructure::Data& data) const;
-  bool checkIfDataContainsNeededParsedBlocks(const datastructure::Data& data) const;
+  static void setDataInMeasurementData(const float& angle,
+                                       const float& angle_delta,
+                                       std::vector<uint8_t>::const_iterator data_ptr,
+                                       datastructure::MeasurementData& measurement_data);
+  static void setNumberOfBeamsInMeasurementData(std::vector<uint8_t>::const_iterator data_ptr,
+                                                datastructure::MeasurementData& measurement_data);
+  static void setScanPointsInMeasurementData(const float& angle,
+                                             const float& angle_delta,
+                                             std::vector<uint8_t>::const_iterator data_ptr,
+                                             datastructure::MeasurementData& measurement_data);
+  static void addScanPointToMeasurementData(const uint16_t offset,
+                                            const float& angle,
+                                            std::vector<uint8_t>::const_iterator data_ptr,
+                                            datastructure::MeasurementData& measurement_data);
+  static bool checkIfPreconditionsAreMet(const datastructure::Data& data);
+  static bool checkIfMeasurementDataIsPublished(const datastructure::Data& data);
+  static bool checkIfDataContainsNeededParsedBlocks(const datastructure::Data& data);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseMeasurementPersistentConfigData.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseMeasurementPersistentConfigData.h
@@ -52,12 +52,13 @@ namespace data_processing {
  */
 class ParseMeasurementPersistentConfigData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseMeasurementPersistentConfigData();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the persistent configuration of the sensor.
    *
@@ -66,22 +67,22 @@ public:
    *
    * \returns If parsing was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::ConfigData& config_data) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               datastructure::ConfigData& config_data);
 
 private:
-  std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  bool readEnabled(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readInterfaceType(std::vector<uint8_t>::const_iterator data_ptr) const;
-  boost::asio::ip::address_v4 readHostIp(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readHostPort(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readPublishingFreq(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readEndAngle(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readStartAngle(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readFeatures(std::vector<uint8_t>::const_iterator data_ptr) const;
+  static std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static bool readEnabled(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readInterfaceType(std::vector<uint8_t>::const_iterator data_ptr);
+  static boost::asio::ip::address_v4 readHostIp(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readHostPort(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readPublishingFreq(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readEndAngle(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readStartAngle(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readFeatures(std::vector<uint8_t>::const_iterator data_ptr);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseMonitoringCaseData.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseMonitoringCaseData.h
@@ -53,12 +53,13 @@ namespace data_processing {
  */
 class ParseMonitoringCaseData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseMonitoringCaseData();
 
+public:
   /*!
    * \brief Parses a tcp sequence and return the monitoring case data.
    *
@@ -67,15 +68,15 @@ public:
    *
    * \returns If parsing the sequence was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::MonitoringCaseData& monitoring_case_data) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               datastructure::MonitoringCaseData& monitoring_case_data);
 
 private:
-  bool isValid(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readMonitoringCaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readFieldIndex(std::vector<uint8_t>::const_iterator data_ptr,
-                          const uint8_t& index) const;
-  bool readFieldValid(std::vector<uint8_t>::const_iterator data_ptr, const uint8_t& index) const;
+  static bool isValid(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readMonitoringCaseNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readFieldIndex(std::vector<uint8_t>::const_iterator data_ptr,
+                                 const uint8_t& index);
+  static bool readFieldValid(std::vector<uint8_t>::const_iterator data_ptr, const uint8_t& index);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseOrderNumber.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseOrderNumber.h
@@ -53,12 +53,13 @@ namespace data_processing {
  */
 class ParseOrderNumber
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseOrderNumber();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the order number of the sensor.
    *
@@ -67,10 +68,10 @@ public:
    *
    * \returns If parsing the order number was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::OrderNumber& order_number) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               datastructure::OrderNumber& order_number);
 
-  std::string readOrderNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
+  static std::string readOrderNumber(std::vector<uint8_t>::const_iterator data_ptr);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseProjectName.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseProjectName.h
@@ -53,12 +53,13 @@ namespace data_processing {
  */
 class ParseProjectName
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseProjectName();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the project name of the sensor.
    *
@@ -67,10 +68,10 @@ public:
    *
    * \returns If parsing the project name was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::ProjectName& project_name) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               datastructure::ProjectName& project_name);
 
-  std::string readProjectName(std::vector<uint8_t>::const_iterator data_ptr) const;
+  static std::string readProjectName(std::vector<uint8_t>::const_iterator data_ptr);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseRequiredUserAction.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseRequiredUserAction.h
@@ -51,12 +51,13 @@ namespace data_processing {
  */
 class ParseRequiredUserActionData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseRequiredUserActionData();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the  required user action of the sensor.
    *
@@ -66,12 +67,12 @@ public:
    *
    * \returns If parsing was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::RequiredUserAction& required_user_action) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               datastructure::RequiredUserAction& required_user_action);
 
 private:
-  bool readRequiredUserAction(std::vector<uint8_t>::const_iterator data_ptr,
-                              datastructure::RequiredUserAction& required_user_action) const;
+  static bool readRequiredUserAction(std::vector<uint8_t>::const_iterator data_ptr,
+                                     datastructure::RequiredUserAction& required_user_action);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseSerialNumber.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseSerialNumber.h
@@ -53,12 +53,13 @@ namespace data_processing {
  */
 class ParseSerialNumber
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseSerialNumber();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the serial number of the sensor.
    *
@@ -67,10 +68,10 @@ public:
    *
    * \returns If parsing the serial number was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::SerialNumber& serial_number) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               datastructure::SerialNumber& serial_number);
 
-  std::string readSerialNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
+  static std::string readSerialNumber(std::vector<uint8_t>::const_iterator data_ptr);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseStatusOverview.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseStatusOverview.h
@@ -51,12 +51,13 @@ namespace data_processing {
  */
 class ParseStatusOverviewData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseStatusOverviewData();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the status overview of the sensor.
    *
@@ -65,23 +66,23 @@ public:
    *
    * \returns If parsing was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::StatusOverview& status_overview) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                        datastructure::StatusOverview& status_overview);
 
 private:
-  std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readDeviceState(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readConfigState(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readApplicationState(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readPowerOnCount(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readCurrentTime(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readCurrentDate(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readErrorInfoCode(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readErrorInfoTime(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readErrorInfoDate(std::vector<uint8_t>::const_iterator data_ptr) const;
+  static std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readDeviceState(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readConfigState(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readApplicationState(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readPowerOnCount(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readCurrentTime(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readCurrentDate(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readErrorInfoCode(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readErrorInfoTime(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readErrorInfoDate(std::vector<uint8_t>::const_iterator data_ptr);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseTCPPacket.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseTCPPacket.h
@@ -58,12 +58,13 @@ namespace data_processing {
  */
 class ParseTCPPacket
 {
-public:
+private:
   /*!
    * \brief Constructor of parser.
    */
   ParseTCPPacket();
 
+public:
   /*!
    * \brief Parse the tcp sequence to get the header information of the cola2 protocol.
    *
@@ -72,8 +73,8 @@ public:
    *
    * \returns If parsing was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        sick::cola2::Command& command) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               sick::cola2::Command& command);
 
   /*!
    * \brief Gets the expected packet length for a buffer.
@@ -82,7 +83,7 @@ public:
    *
    * \returns Expected length of the incoming packet buffer.
    */
-  uint32_t getExpectedPacketLength(const datastructure::PacketBuffer& buffer);
+  static uint32_t getExpectedPacketLength(const datastructure::PacketBuffer& buffer);
 
   /*!
    * \brief Gets the request ID of the incoming tcp packet.
@@ -91,21 +92,21 @@ public:
    *
    * \returns The request ID of the incoming packet buffer.
    */
-  uint16_t getRequestID(const datastructure::PacketBuffer& buffer) const;
+  static uint16_t getRequestID(const datastructure::PacketBuffer& buffer);
 
 private:
-  uint32_t readSTx(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readLength(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readRequestID(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readHubCntr(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readNoC(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readSessionID(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readCommandType(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readCommandMode(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint16_t readErrorCode(std::vector<uint8_t>::const_iterator data_ptr) const;
-  std::vector<uint8_t> readData(const datastructure::PacketBuffer& buffer) const;
-  void setCommandValuesFromPacket(const sick::datastructure::PacketBuffer& buffer,
-                                  sick::cola2::Command& command) const;
+  static uint32_t readSTx(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readLength(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readRequestID(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readHubCntr(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readNoC(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readSessionID(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readCommandType(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readCommandMode(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint16_t readErrorCode(std::vector<uint8_t>::const_iterator data_ptr);
+  static std::vector<uint8_t> readData(const datastructure::PacketBuffer& buffer);
+  static void setCommandValuesFromPacket(const sick::datastructure::PacketBuffer& buffer,
+                                         sick::cola2::Command& command);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseTypeCodeData.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseTypeCodeData.h
@@ -51,12 +51,13 @@ namespace data_processing {
  */
 class ParseTypeCodeData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseTypeCodeData();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the type code of the sensor.
    *
@@ -65,13 +66,13 @@ public:
    *
    * \returns If parsing was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::TypeCode& type_code) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               datastructure::TypeCode& type_code);
 
 private:
-  std::string readTypeCode(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readInterfaceType(std::vector<uint8_t>::const_iterator data_ptr) const;
-  float readMaxRange(std::vector<uint8_t>::const_iterator data_ptr) const;
+  static std::string readTypeCode(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readInterfaceType(std::vector<uint8_t>::const_iterator data_ptr);
+  static float readMaxRange(std::vector<uint8_t>::const_iterator data_ptr);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ParseUserNameData.h
+++ b/include/sick_safetyscanners_base/data_processing/ParseUserNameData.h
@@ -51,12 +51,13 @@ namespace data_processing {
  */
 class ParseUserNameData
 {
-public:
+private:
   /*!
    * \brief Constructor of the parser.
    */
   ParseUserNameData();
 
+public:
   /*!
    * \brief Parses a tcp sequence to read the type code of the sensor.
    *
@@ -65,16 +66,16 @@ public:
    *
    * \returns If parsing was successful.
    */
-  bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                        datastructure::UserName& user_name) const;
+  static bool parseTCPSequence(const datastructure::PacketBuffer& buffer,
+                               datastructure::UserName& user_name);
 
 private:
-  std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const;
-  uint32_t readNameLength(std::vector<uint8_t>::const_iterator data_ptr) const;
-  std::string readUserName(std::vector<uint8_t>::const_iterator data_ptr) const;
+  static std::string readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint8_t readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr);
+  static uint32_t readNameLength(std::vector<uint8_t>::const_iterator data_ptr);
+  static std::string readUserName(std::vector<uint8_t>::const_iterator data_ptr);
 };
 
 } // namespace data_processing

--- a/include/sick_safetyscanners_base/data_processing/ReadWriteHelper.hpp
+++ b/include/sick_safetyscanners_base/data_processing/ReadWriteHelper.hpp
@@ -173,6 +173,21 @@ inline void writeUint32LittleEndian(std::vector<uint8_t>::iterator it, const uin
 }
 
 /*!
+ * \brief Writes an signed 32-bit integer to a buffer at offset in little endian encoding.
+ *
+ * \param buf The buffer to write to.
+ * \param v Value which will be written.
+
+ */
+inline void writeInt32LittleEndian(std::vector<uint8_t>::iterator it, const int32_t v)
+{
+  *(it + 3) = (v & 0xff000000) >> 24;
+  *(it + 2) = (v & 0xff0000) >> 16;
+  *(it + 1) = (v & 0xff00) >> 8;
+  *(it + 0) = v & 0xff;
+}
+
+/*!
  * \brief Read an unsigned 8-bit integer at offset.
  *
  * \param buf Buffer to read from.

--- a/include/sick_safetyscanners_base/datastructure/ApplicationData.h
+++ b/include/sick_safetyscanners_base/datastructure/ApplicationData.h
@@ -57,7 +57,7 @@ public:
    *
    * \returns The application input.
    */
-  ApplicationInputs getInputs() const;
+  const ApplicationInputs& getInputs() const;
   /*!
    * \brief Sets the application input.
    *
@@ -70,7 +70,7 @@ public:
    *
    * \returns The application output.
    */
-  ApplicationOutputs getOutputs() const;
+  const ApplicationOutputs& getOutputs() const;
   /*!
    * \brief Sets the application output.
    *

--- a/include/sick_safetyscanners_base/datastructure/ApplicationInputs.h
+++ b/include/sick_safetyscanners_base/datastructure/ApplicationInputs.h
@@ -60,13 +60,14 @@ public:
    *
    * \returns The unsafe input sources.
    */
-  std::vector<bool> getUnsafeInputsInputSourcesVector() const;
+  const std::vector<bool>& getUnsafeInputsInputSourcesVector() const;
+
+  /*!
+   * \brief Sets the unsafe input sources.
+   *
+   * \param unsafe_inputs_input_sources_vector The unsafe input sources.
+   */
   void
-    /*!
-     * \brief Sets the unsafe input sources.
-     *
-     * \param unsafe_inputs_input_sources_vector The unsafe input sources.
-     */
   setUnsafeInputsInputSourcesVector(const std::vector<bool>& unsafe_inputs_input_sources_vector);
 
   /*!
@@ -78,7 +79,8 @@ public:
    *
    * \returns The unsafe input sources flags.
    */
-  std::vector<bool> getUnsafeInputsFlagsVector() const;
+  const std::vector<bool>& getUnsafeInputsFlagsVector() const;
+
   /*!
    * \brief Sets the unsafe input sources flags.
    *
@@ -91,7 +93,8 @@ public:
    *
    * \returns The monitoring case vector.
    */
-  std::vector<uint16_t> getMonitoringCasevector() const;
+  const std::vector<uint16_t>& getMonitoringCasevector() const;
+
   /*!
    * \brief Sets the monitoring case vector.
    *
@@ -104,7 +107,8 @@ public:
    *
    * \returns The monitoring case flags.
    */
-  std::vector<bool> getMonitoringCaseFlagsVector() const;
+  const std::vector<bool>& getMonitoringCaseFlagsVector() const;
+
   /*!
    * \brief Sets the monitoring case flags.
    *
@@ -118,6 +122,7 @@ public:
    * \returns The first linear velocity input.
    */
   int16_t getVelocity0() const;
+
   /*!
    * \brief Sets the first linear velocity input.
    *
@@ -131,6 +136,7 @@ public:
    * \returns The second linear velocity input
    */
   int16_t getVelocity1() const;
+
   /*!
    * \brief Sets the second linear velocity input.
    *
@@ -144,6 +150,7 @@ public:
    * \returns  If first linear velocity input is valid.
    */
   bool getVelocity0Valid() const;
+
   /*!
    * \brief Sets if first linear velocity input is valid.
    *
@@ -157,6 +164,7 @@ public:
    * \returns If second linear velocity input is valid.
    */
   bool getVelocity1Valid() const;
+
   /*!
    * \brief If second linear velocity input is valid.
    *
@@ -170,6 +178,7 @@ public:
    * \returns If first linear velocity input is transmitted safely.
    */
   bool getVelocity0TransmittedSafely() const;
+
   /*!
    * \brief Sets if first linear velocity input is transmitted safely.
    *
@@ -183,6 +192,7 @@ public:
    * \returns If second linear velocity input is transmitted safely.
    */
   bool getVelocity1TransmittedSafely() const;
+
   /*!
    * \brief Sets if second linear velocity input is transmitted safely.
    *
@@ -196,6 +206,7 @@ public:
    * \returns The state of the sleep mode.
    */
   int8_t getSleepModeInput() const;
+
   /*!
    * \brief Sets the state of the sleep mode.
    *

--- a/include/sick_safetyscanners_base/datastructure/ApplicationName.h
+++ b/include/sick_safetyscanners_base/datastructure/ApplicationName.h
@@ -57,7 +57,7 @@ public:
    *
    * \returns The version indicator for the scanner.
    */
-  std::string getVersionCVersion() const;
+  const std::string& getVersionCVersion() const;
   /*!
    * \brief Sets the version indicator for the scanner.
    *
@@ -120,7 +120,7 @@ public:
    *
    * \returns The application name for the scanner.
    */
-  std::string getApplicationName() const;
+  const std::string& getApplicationName() const;
   /*!
    * \brief Sets the application name for the scanner.
    *

--- a/include/sick_safetyscanners_base/datastructure/ApplicationOutputs.h
+++ b/include/sick_safetyscanners_base/datastructure/ApplicationOutputs.h
@@ -58,7 +58,7 @@ public:
    *
    * \returns The state of the non safe cut-off paths.
    */
-  std::vector<bool> getEvalOutVector() const;
+  const std::vector<bool>& getEvalOutVector() const;
   /*!
    * \brief Set the state of the non safe cut-off paths.
    *
@@ -71,7 +71,7 @@ public:
    *
    * \returns If a cut-off path is safe.
    */
-  std::vector<bool> getEvalOutIsSafeVector() const;
+  const std::vector<bool>& getEvalOutIsSafeVector() const;
   /*!
    * \brief Sets if an cut-off path is safe.
    *
@@ -84,7 +84,7 @@ public:
    *
    * \returns If the output path is valid.
    */
-  std::vector<bool> getEvalOutIsValidVector() const;
+  const std::vector<bool>& getEvalOutIsValidVector() const;
   /*!
    * \brief Sets if an output path is valid.
    *
@@ -97,7 +97,7 @@ public:
    *
    * \returns The monitoring case numbers.
    */
-  std::vector<uint16_t> getMonitoringCaseVector() const;
+  const std::vector<uint16_t>& getMonitoringCaseVector() const;
   /*!
    * \brief Sets the currently active monitoring case numbers.
    *
@@ -110,7 +110,7 @@ public:
    *
    * \returns If the monitoring case number is valid.
    */
-  std::vector<bool> getMonitoringCaseFlagsVector() const;
+  const std::vector<bool>& getMonitoringCaseFlagsVector() const;
   /*!
    * \brief Set is the corresponding monitoring case number is valid.
    *
@@ -293,7 +293,7 @@ public:
    *
    * \returns  The resulting velocity for each monitoring case table.
    */
-  std::vector<int16_t> getResultingVelocityVector() const;
+  const std::vector<int16_t>& getResultingVelocityVector() const;
   /*!
    * \brief Sets the resulting velocity for each monitoring case table.
    *
@@ -306,13 +306,14 @@ public:
    *
    * \returns  If the resulting velocities are valid.
    */
-  std::vector<bool> getResultingVelocityIsValidVector() const;
+  const std::vector<bool>& getResultingVelocityIsValidVector() const;
+
+  /*!
+   * \brief Sets if the resulting velocities are valid.
+   *
+   * \param resulting_velocity_is_valid_vector If the resulting velocities are valid.
+   */
   void
-    /*!
-     * \brief Sets if the resulting velocities are valid.
-     *
-     * \param resulting_velocity_is_valid_vector If the resulting velocities are valid.
-     */
   setResultingVelocityIsValidVector(const std::vector<bool>& resulting_velocity_is_valid_vector);
 
   /*!

--- a/include/sick_safetyscanners_base/datastructure/CommSettings.h
+++ b/include/sick_safetyscanners_base/datastructure/CommSettings.h
@@ -142,26 +142,26 @@ public:
    *
    * \returns The start angle of the scan.
    */
-  uint32_t getStartAngle() const;
+  int32_t getStartAngle() const;
   /*!
    * \brief Sets the start angle of the scan.
    *
    * \param start_angle The start angle of the scan.
    */
-  void setStartAngle(const uint32_t& start_angle);
+  void setStartAngle(const float& start_angle);
 
   /*!
    * \brief Gets the end angle of the scan.
    *
    * \returns The end angle of the scan.
    */
-  uint32_t getEndAngle() const;
+  int32_t getEndAngle() const;
   /*!
    * \brief Sets the end angle of the scan.
    *
    * \param end_angle The end angle of the scan.
    */
-  void setEndAngle(const uint32_t& end_angle);
+  void setEndAngle(const float& end_angle);
 
   /*!
    * \brief Gets the enabled features.
@@ -231,8 +231,8 @@ private:
   bool m_enabled;
   uint8_t m_e_interface_type;
   uint16_t m_publishing_frequency;
-  uint32_t m_start_angle;
-  uint32_t m_end_angle;
+  int32_t m_start_angle;
+  int32_t m_end_angle;
   uint16_t m_features;
 };
 

--- a/include/sick_safetyscanners_base/datastructure/ConfigData.h
+++ b/include/sick_safetyscanners_base/datastructure/ConfigData.h
@@ -59,7 +59,7 @@ public:
    *
    * \returns The version indicator for the scanner.
    */
-  std::string getVersionCVersion() const;
+  const std::string& getVersionCVersion() const;
   /*!
    * \brief Sets the version indicator for the scanner.
    *

--- a/include/sick_safetyscanners_base/datastructure/ConfigMetadata.h
+++ b/include/sick_safetyscanners_base/datastructure/ConfigMetadata.h
@@ -58,7 +58,7 @@ public:
    *
    * \returns The version indicator for the scanner.
    */
-  std::string getVersionCVersion() const;
+  const std::string& getVersionCVersion() const;
   /*!
    * \brief Sets the version indicator for the scanner.
    *
@@ -188,7 +188,8 @@ public:
    *
    * \returns The integrity hash for the scanner.
    */
-  std::vector<uint32_t> getIntegrityHash() const;
+  const std::vector<uint32_t>& getIntegrityHash() const;
+
   /*!
    * \brief Sets the integrity hash for the scanner.
    *

--- a/include/sick_safetyscanners_base/datastructure/DeviceName.h
+++ b/include/sick_safetyscanners_base/datastructure/DeviceName.h
@@ -57,7 +57,7 @@ public:
    *
    * \returns The device name for the scanner.
    */
-  std::string getDeviceName() const;
+  const std::string& getDeviceName() const;
   /*!
    * \brief Sets the device name for the scanner.
    *

--- a/include/sick_safetyscanners_base/datastructure/DeviceStatus.h
+++ b/include/sick_safetyscanners_base/datastructure/DeviceStatus.h
@@ -82,6 +82,25 @@ private:
 };
 
 
+inline std::string sopasDeviceStatusToString(DeviceStatus::e_sopas_device_status deviceStatus)
+{
+  switch( deviceStatus )
+  {
+    case DeviceStatus::E_UNKNOWN:             return "UNKNOWN";
+    case DeviceStatus::E_START_UP:            return "START_UP";
+    case DeviceStatus::E_SERVICE_MODE:        return "SERVICE_MODE";
+    case DeviceStatus::E_NORMAL_OPERATION:    return "NORMAL_OPERATION";
+    case DeviceStatus::E_SUSPENDED_OPERATION: return "SUSPENDED_OPERATION";
+    case DeviceStatus::E_SERVICE_RECOMMENDED: return "SERVICE_RECOMMENDED";
+    case DeviceStatus::E_SERVICE_REQUIRED:    return "SERVICE_REQUIRED";
+    case DeviceStatus::E_RECOVERABLE_ERROR:   return "RECOVERABLE_ERROR";
+    case DeviceStatus::E_FATAL_ERROR:         return "FATAL_ERROR";
+  }
+
+  return std::string();
+}
+
+
 } // namespace datastructure
 } // namespace sick
 

--- a/include/sick_safetyscanners_base/datastructure/FieldData.h
+++ b/include/sick_safetyscanners_base/datastructure/FieldData.h
@@ -66,13 +66,13 @@ public:
    * \param is_valid if the field data is valid.
    */
   void setIsValid(bool is_valid);
-  ;
+
   /*!
    * \brief Gets the version indicator for the scanner.
    *
    * \returns The version indicator for the scanner.
    */
-  std::string getVersionCVersion() const;
+  const std::string& getVersionCVersion() const;
   /*!
    * \brief Sets the version indicator for the scanner.
    *
@@ -132,7 +132,6 @@ public:
    * \param is_defined if the field data is defined.
    */
   void setIsDefined(bool is_defined);
-  ;
 
   /*!
    * \brief Returns the configured eval method.
@@ -161,7 +160,6 @@ public:
    * \param multi_sampling The configured multiple sampling.
    */
   void setMultiSampling(const uint16_t& multi_sampling);
-  ;
 
   /*!
    * \brief Returns the configured object resolution.
@@ -176,7 +174,7 @@ public:
    * \param object_resolution The configured object resolution.
    */
   void setObjectResolution(const uint16_t& object_resolution);
-  ;
+
   /*!
    * \brief Returns the index of the field set the field belongs to.
    *
@@ -207,7 +205,7 @@ public:
    *
    * \returns The current field name.
    */
-  std::string getFieldName() const;
+  const std::string& getFieldName() const;
   /*!
    * \brief Sets the field name.
    *
@@ -248,7 +246,7 @@ public:
    *
    * \returns Vector with beam distances.
    */
-  std::vector<uint16_t> getBeamDistances() const;
+  const std::vector<uint16_t>& getBeamDistances() const;
 
   /*!
    * \brief Sets vector with beam distances for field.

--- a/include/sick_safetyscanners_base/datastructure/FieldSets.h
+++ b/include/sick_safetyscanners_base/datastructure/FieldSets.h
@@ -57,7 +57,7 @@ public:
    *
    * \returns The version indicator for the scanner.
    */
-  std::string getVersionCVersion() const;
+  const std::string& getVersionCVersion() const;
   /*!
    * \brief Sets the version indicator for the scanner.
    *
@@ -108,7 +108,7 @@ public:
    *
    * \returns The length of the field name.
    */
-  std::vector<uint32_t> getNameLength() const;
+  const std::vector<uint32_t>& getNameLength() const;
   /*!
    * \brief Sets the length of the field name.
    *
@@ -120,7 +120,7 @@ public:
    *
    * \returns The field name for the scanner.
    */
-  std::vector<std::string> getFieldName() const;
+  const std::vector<std::string>& getFieldName() const;
   /*!
    * \brief Sets the field name for the scanner.
    *
@@ -133,7 +133,7 @@ public:
    *
    * \returns if the fields are defined.
    */
-  std::vector<bool> getIsDefined() const;
+  const std::vector<bool>& getIsDefined() const;
   /*!
    * \brief Sets if the fields are defined.
    *

--- a/include/sick_safetyscanners_base/datastructure/FirmwareVersion.h
+++ b/include/sick_safetyscanners_base/datastructure/FirmwareVersion.h
@@ -57,7 +57,7 @@ public:
    *
    * \returns The firmware version for the scanner.
    */
-  std::string getFirmwareVersion() const;
+  const std::string& getFirmwareVersion() const;
   /*!
    * \brief Sets the firmware version for the scanner.
    *

--- a/include/sick_safetyscanners_base/datastructure/GeneralSystemState.h
+++ b/include/sick_safetyscanners_base/datastructure/GeneralSystemState.h
@@ -129,7 +129,7 @@ public:
    * \brief Returns the state for all safe cut off paths.
    * \return Vector containing the state of all safe cut off paths.
    */
-  std::vector<bool> getSafeCutOffPathVector() const;
+  const std::vector<bool>& getSafeCutOffPathVector() const;
 
   /*!
    * \brief Sets the state of all safe cut-off paths.
@@ -141,7 +141,7 @@ public:
    * \brief Returns the state of all non-safe cut-off paths.
    * \return  Vector containing the state of all non-safe cut-off paths
    */
-  std::vector<bool> getNonSafeCutOffPathVector() const;
+  const std::vector<bool>& getNonSafeCutOffPathVector() const;
 
   /*!
    * \brief Sets the state of all non-safe cut-off paths.
@@ -153,7 +153,7 @@ public:
    * \brief Returns if a cut-off path has to be reset.
    * \return Vector if a cut-off path has to be reset.
    */
-  std::vector<bool> getResetRequiredCutOffPathVector() const;
+  const std::vector<bool>& getResetRequiredCutOffPathVector() const;
 
   /*!
    * \brief Sets the reset state for all cut-off paths

--- a/include/sick_safetyscanners_base/datastructure/IntrusionData.h
+++ b/include/sick_safetyscanners_base/datastructure/IntrusionData.h
@@ -57,7 +57,7 @@ public:
    * \brief Getter for all IntrusionDatums.
    * \return Vector of IntrusionDatum.
    */
-  std::vector<IntrusionDatum> getIntrusionDataVector() const;
+  const std::vector<IntrusionDatum>& getIntrusionDataVector() const;
 
   /*!
    * \brief Setter for the vector of IntrusionDatums.

--- a/include/sick_safetyscanners_base/datastructure/IntrusionDatum.h
+++ b/include/sick_safetyscanners_base/datastructure/IntrusionDatum.h
@@ -68,7 +68,7 @@ public:
    * \brief Getter for the flags vector.
    * \return Boolean vector of all flags
    */
-  std::vector<bool> getFlagsVector() const;
+  const std::vector<bool>& getFlagsVector() const;
 
   /*!
    * \brief Setter for the flag vector

--- a/include/sick_safetyscanners_base/datastructure/MeasurementData.h
+++ b/include/sick_safetyscanners_base/datastructure/MeasurementData.h
@@ -70,7 +70,7 @@ public:
    * \brief Getter for all contained scanpoints.
    * \return Vector of scanpoints.
    */
-  std::vector<ScanPoint> getScanPointsVector() const;
+  const std::vector<ScanPoint>& getScanPointsVector() const;
 
   /*!
    * \brief Add a single scanpoint to the vector of scanpoints.

--- a/include/sick_safetyscanners_base/datastructure/MonitoringCaseData.h
+++ b/include/sick_safetyscanners_base/datastructure/MonitoringCaseData.h
@@ -87,7 +87,7 @@ public:
    *
    * \returns The field indices.
    */
-  std::vector<uint16_t> getFieldIndices() const;
+  const std::vector<uint16_t>& getFieldIndices() const;
 
   /*!
    * \brief Sets the field indices.
@@ -101,7 +101,7 @@ public:
    *
    * \returns If the fields are valid.
    */
-  std::vector<bool> getFieldsValid() const;
+  const std::vector<bool>& getFieldsValid() const;
 
   /*!
    * \brief Sets if the fields are valid.

--- a/include/sick_safetyscanners_base/datastructure/OrderNumber.h
+++ b/include/sick_safetyscanners_base/datastructure/OrderNumber.h
@@ -57,7 +57,7 @@ public:
    *
    * \returns The order number for the scanner.
    */
-  std::string getOrderNumber() const;
+  const std::string& getOrderNumber() const;
   /*!
    * \brief Sets the order number for the scanner.
    *

--- a/include/sick_safetyscanners_base/datastructure/ProjectName.h
+++ b/include/sick_safetyscanners_base/datastructure/ProjectName.h
@@ -57,7 +57,7 @@ public:
    *
    * \returns The project name for the scanner.
    */
-  std::string getProjectName() const;
+  const std::string& getProjectName() const;
   /*!
    * \brief Sets the project name for the scanner.
    *

--- a/include/sick_safetyscanners_base/datastructure/SerialNumber.h
+++ b/include/sick_safetyscanners_base/datastructure/SerialNumber.h
@@ -57,7 +57,7 @@ public:
    *
    * \returns The serial number for the scanner.
    */
-  std::string getSerialNumber() const;
+  const std::string& getSerialNumber() const;
   /*!
    * \brief Sets the serial number for the scanner.
    *

--- a/include/sick_safetyscanners_base/datastructure/StatusOverview.h
+++ b/include/sick_safetyscanners_base/datastructure/StatusOverview.h
@@ -88,7 +88,7 @@ public:
    *
    * \returns The version indicator for the scanner.
    */
-  std::string getVersionCVersion() const;
+  const std::string& getVersionCVersion() const;
   /*!
    * \brief Sets the version indicator for the scanner.
    *

--- a/include/sick_safetyscanners_base/datastructure/StatusOverview.h
+++ b/include/sick_safetyscanners_base/datastructure/StatusOverview.h
@@ -49,33 +49,33 @@ class StatusOverview
 public:
   enum e_device_state
   {
-    E_NORMAL,
-    E_ERROR,
-    E_INITIALIZATION,
-    E_SHUTDOWN,
-    E_OPTICS_COVER_CALIBRATION
+    E_NORMAL                    = 0x0,
+    E_ERROR                     = 0x1,
+    E_INITIALIZATION            = 0x2,
+    E_SHUTDOWN                  = 0x3,
+    E_OPTICS_COVER_CALIBRATION  = 0x4
   };
 
   enum e_config_state
   {
-    E_UNKNOWN,
-    E_CONFIG_REQUIRED,
-    E_CONFIG_IN_PROGRESS,
-    E_NOT_VERIFIED,
-    E_REJECTED,
-    E_VERIFIED,
-    E_INTERNAL_ERROR,
-    E_VERIFICATION_IN_PROGRESS
+    E_UNKNOWN                   = 0x0,
+    E_CONFIG_REQUIRED           = 0x1,
+    E_CONFIG_IN_PROGRESS        = 0x2,
+    E_NOT_VERIFIED              = 0x3,
+    E_REJECTED                  = 0x4,
+    E_VERIFIED                  = 0x5,
+    E_INTERNAL_ERROR            = 0x6,
+    E_VERIFICATION_IN_PROGRESS  = 0x7
   };
 
   enum e_application_state
   {
-    E_STOPPED,
-    E_STARTING,
-    E_WAITING_FOR_PARTNERS,
-    E_WAITING_FOR_INPUTS,
-    E_STARTED,
-    E_SLEEP_MODE
+    E_STOPPED                   = 0x0,
+    E_STARTING                  = 0x1,
+    E_WAITING_FOR_PARTNERS      = 0x2,
+    E_WAITING_FOR_INPUTS        = 0x3,
+    E_STARTED                   = 0x4,
+    E_SLEEP_MODE                = 0x5
   };
 
   /*!
@@ -226,7 +226,6 @@ public:
    */
   void setErrorInfoCode(uint32_t error_info_code);
 
-
   /*!
    * \brief Gets the error info time for the scanner.
    *
@@ -269,6 +268,54 @@ private:
   uint32_t m_error_info_time;
   uint16_t m_error_info_date;
 };
+
+
+
+inline std::string deviceStateToString(StatusOverview::e_device_state deviceState)
+{
+  switch( deviceState )
+  {
+    case StatusOverview::E_NORMAL:          return "NORMAL";
+    case StatusOverview::E_ERROR:           return "ERROR";
+    case StatusOverview::E_INITIALIZATION:  return "INITIALIZATION";
+    case StatusOverview::E_SHUTDOWN:        return "SHUTDOWN";
+    case StatusOverview::E_OPTICS_COVER_CALIBRATION: return "OPTICS_COVER_CALIBRATION";
+  }
+
+  return std::string();
+}
+
+inline std::string configStateToString(StatusOverview::e_config_state configState)
+{
+  switch( configState )
+  {
+    case StatusOverview::E_UNKNOWN:             return "UNKNOWN";
+    case StatusOverview::E_CONFIG_REQUIRED:     return "CONFIG_REQUIRED";
+    case StatusOverview::E_CONFIG_IN_PROGRESS:  return "CONFIG_IN_PROGRESS";
+    case StatusOverview::E_NOT_VERIFIED:        return "NOT_VERIFIED";
+    case StatusOverview::E_REJECTED:            return "REJECTED";
+    case StatusOverview::E_VERIFIED:            return "VERIFIED";
+    case StatusOverview::E_INTERNAL_ERROR:      return "INTERNAL_ERROR";
+    case StatusOverview::E_VERIFICATION_IN_PROGRESS: return "VERIFICATION_IN_PROGRESS";
+  }
+
+  return std::string();
+}
+
+inline std::string applicationStateToString(StatusOverview::e_application_state applicationState)
+{
+  switch( applicationState )
+  {
+    case StatusOverview::E_STOPPED:               return "STOPPED";
+    case StatusOverview::E_STARTING:              return "STARTING";
+    case StatusOverview::E_WAITING_FOR_PARTNERS:  return "WAITING_FOR_PARTNERS";
+    case StatusOverview::E_WAITING_FOR_INPUTS:    return "WAITING_FOR_INPUTS";
+    case StatusOverview::E_STARTED:               return "STARTED";
+    case StatusOverview::E_SLEEP_MODE:            return "SLEEP_MODE";
+  }
+
+  return std::string();
+}
 
 
 } // namespace datastructure

--- a/include/sick_safetyscanners_base/datastructure/StatusOverview.h
+++ b/include/sick_safetyscanners_base/datastructure/StatusOverview.h
@@ -49,33 +49,33 @@ class StatusOverview
 public:
   enum e_device_state
   {
-    E_NORMAL,
-    E_ERROR,
-    E_INITIALIZATION,
-    E_SHUTDOWN,
-    E_OPTICS_COVER_CALIBRATION
+    E_NORMAL                    = 0x0,
+    E_ERROR                     = 0x1,
+    E_INITIALIZATION            = 0x2,
+    E_SHUTDOWN                  = 0x3,
+    E_OPTICS_COVER_CALIBRATION  = 0x4
   };
 
   enum e_config_state
   {
-    E_UNKNOWN,
-    E_CONFIG_REQUIRED,
-    E_CONFIG_IN_PROGRESS,
-    E_NOT_VERIFIED,
-    E_REJECTED,
-    E_VERIFIED,
-    E_INTERNAL_ERROR,
-    E_VERIFICATION_IN_PROGRESS
+    E_UNKNOWN                   = 0x0,
+    E_CONFIG_REQUIRED           = 0x1,
+    E_CONFIG_IN_PROGRESS        = 0x2,
+    E_NOT_VERIFIED              = 0x3,
+    E_REJECTED                  = 0x4,
+    E_VERIFIED                  = 0x5,
+    E_INTERNAL_ERROR            = 0x6,
+    E_VERIFICATION_IN_PROGRESS  = 0x7
   };
 
   enum e_application_state
   {
-    E_STOPPED,
-    E_STARTING,
-    E_WAITING_FOR_PARTNERS,
-    E_WAITING_FOR_INPUTS,
-    E_STARTED,
-    E_SLEEP_MODE
+    E_STOPPED                   = 0x0,
+    E_STARTING                  = 0x1,
+    E_WAITING_FOR_PARTNERS      = 0x2,
+    E_WAITING_FOR_INPUTS        = 0x3,
+    E_STARTED                   = 0x4,
+    E_SLEEP_MODE                = 0x5
   };
 
   /*!
@@ -88,7 +88,7 @@ public:
    *
    * \returns The version indicator for the scanner.
    */
-  std::string getVersionCVersion() const;
+  const std::string& getVersionCVersion() const;
   /*!
    * \brief Sets the version indicator for the scanner.
    *
@@ -226,7 +226,6 @@ public:
    */
   void setErrorInfoCode(uint32_t error_info_code);
 
-
   /*!
    * \brief Gets the error info time for the scanner.
    *
@@ -269,6 +268,54 @@ private:
   uint32_t m_error_info_time;
   uint16_t m_error_info_date;
 };
+
+
+
+inline std::string deviceStateToString(StatusOverview::e_device_state deviceState)
+{
+  switch( deviceState )
+  {
+    case StatusOverview::E_NORMAL:          return "NORMAL";
+    case StatusOverview::E_ERROR:           return "ERROR";
+    case StatusOverview::E_INITIALIZATION:  return "INITIALIZATION";
+    case StatusOverview::E_SHUTDOWN:        return "SHUTDOWN";
+    case StatusOverview::E_OPTICS_COVER_CALIBRATION: return "OPTICS_COVER_CALIBRATION";
+  }
+
+  return std::string();
+}
+
+inline std::string configStateToString(StatusOverview::e_config_state configState)
+{
+  switch( configState )
+  {
+    case StatusOverview::E_UNKNOWN:             return "UNKNOWN";
+    case StatusOverview::E_CONFIG_REQUIRED:     return "CONFIG_REQUIRED";
+    case StatusOverview::E_CONFIG_IN_PROGRESS:  return "CONFIG_IN_PROGRESS";
+    case StatusOverview::E_NOT_VERIFIED:        return "NOT_VERIFIED";
+    case StatusOverview::E_REJECTED:            return "REJECTED";
+    case StatusOverview::E_VERIFIED:            return "VERIFIED";
+    case StatusOverview::E_INTERNAL_ERROR:      return "INTERNAL_ERROR";
+    case StatusOverview::E_VERIFICATION_IN_PROGRESS: return "VERIFICATION_IN_PROGRESS";
+  }
+
+  return std::string();
+}
+
+inline std::string applicationStateToString(StatusOverview::e_application_state applicationState)
+{
+  switch( applicationState )
+  {
+    case StatusOverview::E_STOPPED:               return "STOPPED";
+    case StatusOverview::E_STARTING:              return "STARTING";
+    case StatusOverview::E_WAITING_FOR_PARTNERS:  return "WAITING_FOR_PARTNERS";
+    case StatusOverview::E_WAITING_FOR_INPUTS:    return "WAITING_FOR_INPUTS";
+    case StatusOverview::E_STARTED:               return "STARTED";
+    case StatusOverview::E_SLEEP_MODE:            return "SLEEP_MODE";
+  }
+
+  return std::string();
+}
 
 
 } // namespace datastructure

--- a/include/sick_safetyscanners_base/datastructure/TypeCode.h
+++ b/include/sick_safetyscanners_base/datastructure/TypeCode.h
@@ -72,7 +72,7 @@ public:
    *
    * \returns The type code for the scanner.
    */
-  std::string getTypeCode() const;
+  const std::string& getTypeCode() const;
   /*!
    * \brief Sets the type code for the scanner.
    *

--- a/include/sick_safetyscanners_base/datastructure/UserName.h
+++ b/include/sick_safetyscanners_base/datastructure/UserName.h
@@ -57,7 +57,7 @@ public:
    *
    * \returns The version indicator for the scanner.
    */
-  std::string getVersionCVersion() const;
+  const std::string& getVersionCVersion() const;
   /*!
    * \brief Sets the version indicator for the scanner.
    *
@@ -120,7 +120,7 @@ public:
    *
    * \returns The user name for the scanner.
    */
-  std::string getUserName() const;
+  const std::string& getUserName() const;
   /*!
    * \brief Sets the user name for the scanner.
    *

--- a/include/sick_safetyscanners_base/logging/logging_wrapper.h
+++ b/include/sick_safetyscanners_base/logging/logging_wrapper.h
@@ -1,13 +1,19 @@
 #ifndef SICK_SAFETYSCANNERS_BASE_LOGGING_LOGGINGWRAPPER_H
 #define SICK_SAFETYSCANNERS_BASE_LOGGING_LOGGINGWRAPPER_H
 
-#ifdef NO_ROS_LOGGING
+#ifdef NO_LOGGING
+
+#define ROS_INFO(...) do{} while(false)
+#define ROS_WARN(...) do{} while(false)
+#define ROS_ERROR(...) do{} while(false)
+
+#elif NO_ROS_LOGGING
 // clang-format off
 #include <cstdio>
 
-#define ROS_INFO(...) std::printf(__VA_ARGS__)
-#define ROS_WARN(...) std::printf(__VA_ARGS__)
-#define ROS_ERROR(...) std::fprintf(stderr, __VA_ARGS__)
+#define ROS_INFO(...) std::printf(__VA_ARGS__); std::printf("\n"); fflush(stdout)
+#define ROS_WARN(...) std::printf(__VA_ARGS__); std::printf("\n"); fflush(stdout)
+#define ROS_ERROR(...) std::fprintf(stderr, __VA_ARGS__); std::fprintf(stderr, "\n"); fflush(stderr)
 
 #else
 

--- a/src/SickSafetyscannersBase.cpp
+++ b/src/SickSafetyscannersBase.cpp
@@ -448,15 +448,14 @@ void SickSafetyscannersBase::stopTCPConnection()
   m_session_ptr->doDisconnect();
 }
 
-
 void SickSafetyscannersBase::processUDPPacket(const sick::datastructure::PacketBuffer& buffer)
 {
   if (m_packet_merger_ptr->addUDPPacket(buffer))
   {
     sick::datastructure::PacketBuffer deployed_buffer =
       m_packet_merger_ptr->getDeployedPacketBuffer();
-    sick::data_processing::ParseData data_parser;
-    sick::datastructure::Data data = data_parser.parseUDPSequence(deployed_buffer);
+
+    sick::datastructure::Data data = sick::data_processing::ParseData::parseUDPSequence(deployed_buffer);
 
     m_newPacketReceivedCallbackFunction(data);
   }

--- a/src/SickSafetyscannersBase.cpp
+++ b/src/SickSafetyscannersBase.cpp
@@ -32,6 +32,7 @@
  */
 //----------------------------------------------------------------------
 
+#include <sick_safetyscanners_base/logging/logging_wrapper.h>
 
 #include "sick_safetyscanners_base/SickSafetyscannersBase.h"
 

--- a/src/SickSafetyscannersBase.cpp
+++ b/src/SickSafetyscannersBase.cpp
@@ -38,6 +38,192 @@
 
 namespace sick {
 
+
+namespace detail
+{
+  typedef std::shared_ptr<sick::cola2::Cola2Session> Cola2SessionPtr;
+  typedef std::function<void(const boost::system::error_code&, Cola2SessionPtr )> CompleteHandler;
+  typedef std::function<void(const boost::system::error_code&)> AsyncCompleteHandler;
+
+  /**
+   * @brief openCola2Session
+   *
+   * @note The given handler will not be called from within this method
+   *
+   * @param ios
+   * @param settings
+   * @param handler The handler that should be called if the session is opened or an error occured
+   */
+  void openCola2Session(boost::asio::io_service& ios,
+                        const sick::datastructure::CommSettings& settings,
+                        CompleteHandler handler)
+  {
+    std::shared_ptr<sick::communication::AsyncTCPClient> async_tcp_client =
+      std::make_shared<sick::communication::AsyncTCPClient>(
+        ios,
+        settings.getSensorIp(),
+        settings.getSensorTcpPort());
+
+    async_tcp_client->doConnect( [async_tcp_client, handler]( boost::system::error_code ec ) {
+      if ( !ec )
+      {
+        Cola2SessionPtr session = std::make_shared<sick::cola2::Cola2Session>(async_tcp_client);
+        session->open( std::bind(handler, std::placeholders::_1, session) );
+      }
+      else
+      {
+        handler( ec, Cola2SessionPtr() );
+      }
+    });
+  }
+
+  template< typename U, typename T >
+  void processCola2Command(boost::asio::io_service& ios,
+                           const datastructure::CommSettings& settings,
+                           std::reference_wrapper<T> command,
+                           AsyncCompleteHandler handler)
+  {
+    openCola2Session(ios, settings, [command, handler](const boost::system::error_code& ec, Cola2SessionPtr session) {
+      // if there is no error -> create Cola2 Command and execute it
+      if ( !ec )
+      {
+        sick::cola2::Cola2Session::CommandPtr command_ptr = std::make_shared<U>(*session, command);
+
+        session->executeCommand(command_ptr, [session, handler](const boost::system::error_code& ec) {
+          AsyncCompleteHandler nextHandler = handler;
+
+          // if there is an error -> we call the handler and reset it because we always want to close the session
+          // but we cannot call the given handler multiple times.
+          if (ec)
+          {
+            nextHandler( ec );
+            nextHandler = AsyncCompleteHandler();
+          }
+
+          session->close([session, nextHandler](const boost::system::error_code& ec) {
+            session->doDisconnect();  // we always want to disconnect the session/tcp socket
+
+            // it the handler was not already called -> we call it with the given error_code
+            if (nextHandler)
+            {
+              nextHandler( ec );
+            }
+          });
+        });
+      }
+      // if there is an error -> call handler with error code
+      else
+      {
+        handler(ec);
+      }
+    });
+  }
+
+
+  void requestNextFieldData(int index,
+                            Cola2SessionPtr session,
+                            std::shared_ptr<sick::datastructure::ConfigData> config_data,
+                            std::reference_wrapper< std::vector<sick::datastructure::FieldData> > fields,
+                            AsyncCompleteHandler handler )
+  {
+
+    std::shared_ptr< sick::datastructure::FieldData > field_data = std::make_shared<sick::datastructure::FieldData>() ;
+    sick::cola2::Cola2Session::CommandPtr command_ptr = std::make_shared<sick::cola2::FieldHeaderVariableCommand>(*session,
+                                                                                                                  *field_data,
+                                                                                                                  index );
+
+    session->executeCommand(command_ptr, [index, session, config_data, fields, field_data, handler](const boost::system::error_code& ec) {
+      if ( !ec )
+      {
+        sick::cola2::Cola2Session::CommandPtr command2_ptr = std::make_shared<sick::cola2::FieldGeometryVariableCommand>(*session,
+                                                                                                                         *field_data,
+                                                                                                                          index );
+
+        session->executeCommand(command2_ptr, [index, session, config_data, fields, field_data, handler](const boost::system::error_code& ec) {
+          if ( !ec )
+          {
+            if (field_data->getIsValid())
+            {
+              field_data->setStartAngleDegrees(config_data->getDerivedStartAngle());
+              field_data->setAngularBeamResolutionDegrees(config_data->getDerivedAngularBeamResolution());
+              fields.get().push_back( *field_data );
+            }
+
+            if ( index < 128 )
+            {
+              requestNextFieldData( index+1, session, config_data, fields, handler );
+            }
+          }
+          else
+          {
+            handler( ec );
+          }
+        });
+      }
+      else
+      {
+        handler( ec );
+      }
+    });
+  }
+
+
+  void requestFieldData(Cola2SessionPtr session,
+                        std::reference_wrapper< std::vector<sick::datastructure::FieldData> > fields,
+                        AsyncCompleteHandler handler)
+  {
+    std::shared_ptr<sick::datastructure::ConfigData> config_data = std::make_shared<sick::datastructure::ConfigData>();
+    sick::cola2::Cola2Session::CommandPtr command_ptr = std::make_shared<sick::cola2::MeasurementCurrentConfigVariableCommand>(*session,
+                                                                                                                               *config_data);
+
+    session->executeCommand(command_ptr, [session, fields, config_data, handler](const boost::system::error_code& ec) {
+      if ( !ec )
+      {
+        detail::requestNextFieldData( 0, session, config_data, fields, handler);
+      }
+      else
+      {
+        handler(ec);
+      }
+    });
+  }
+
+
+  void requestNextMonitoringCase( int index,
+                                  Cola2SessionPtr session,
+                                  std::reference_wrapper< std::vector<sick::datastructure::MonitoringCaseData> > monitoring_cases,
+                                  AsyncCompleteHandler handler )
+  {
+    std::shared_ptr< sick::datastructure::MonitoringCaseData > monitoring_case_data = std::make_shared<sick::datastructure::MonitoringCaseData>() ;
+    sick::cola2::Cola2Session::CommandPtr command_ptr = std::make_shared<sick::cola2::MonitoringCaseVariableCommand>(*session,
+                                                                                                                     *monitoring_case_data,
+                                                                                                                     index );
+
+    session->executeCommand(command_ptr, [session, index, monitoring_cases, monitoring_case_data, handler](const boost::system::error_code& ec) {
+      if ( !ec )
+      {
+        if (monitoring_case_data->getIsValid())
+        {
+          monitoring_cases.get().push_back( *monitoring_case_data );
+        }
+
+        if ( index < 254 )
+        {
+          requestNextMonitoringCase( index+1, session, monitoring_cases, handler );
+        }
+      }
+      else
+      {
+        handler( ec );
+      }
+    });
+  }
+}
+
+
+
+
+
 SickSafetyscannersBase::SickSafetyscannersBase(
   const packetReceivedCallbackFunction& newPacketReceivedCallbackFunction,
   sick::datastructure::CommSettings* settings)
@@ -68,7 +254,7 @@ bool SickSafetyscannersBase::run()
   m_udp_client_thread_ptr.reset(
     new boost::thread(boost::bind(&SickSafetyscannersBase::udpClientThread, this)));
 
-  m_async_udp_client_ptr->runService();
+  m_async_udp_client_ptr->start();
   return true;
 }
 
@@ -81,372 +267,396 @@ bool SickSafetyscannersBase::udpClientThread()
   return true;
 }
 
-
-void SickSafetyscannersBase::processTCPPacket(const sick::datastructure::PacketBuffer& buffer)
-{
-  // Not needed for current functionality, inplace for possible future developments
-}
-
 void SickSafetyscannersBase::changeSensorSettings(const datastructure::CommSettings& settings)
 {
-  startTCPConnection(settings);
-  changeCommSettingsInColaSession(settings);
-  stopTCPConnection();
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncChangeSensorSettings(settings, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
+}
+
+void SickSafetyscannersBase::asyncChangeSensorSettings(const sick::datastructure::CommSettings& settings, AsyncCompleteHandler handler )
+{
+  detail::processCola2Command<sick::cola2::ChangeCommSettingsCommand>( *m_io_service_ptr, settings, std::ref(settings), handler );
 }
 
 void SickSafetyscannersBase::findSensor(const datastructure::CommSettings& settings,
                                         uint16_t blink_time)
 {
-  startTCPConnection(settings);
-  findSensorInColaSession(blink_time);
-  stopTCPConnection();
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncFindSensor(settings, blink_time, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
+}
+
+void SickSafetyscannersBase::asyncFindSensor(const datastructure::CommSettings& settings, uint16_t blink_time, AsyncCompleteHandler handler)
+{
+  detail::processCola2Command<sick::cola2::FindMeCommand>( *m_io_service_ptr, settings, std::ref(blink_time), handler );
 }
 
 void SickSafetyscannersBase::requestTypeCode(const datastructure::CommSettings& settings,
                                              sick::datastructure::TypeCode& type_code)
-{
-  startTCPConnection(settings);
-  requestTypeCodeInColaSession(type_code);
-  stopTCPConnection();
+{ 
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncRequestTypeCode(settings, type_code, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
+
+  ROS_INFO("Type Code: %s", type_code.getTypeCode().c_str());
 }
 
-void SickSafetyscannersBase::requestApplicationName(
-  const datastructure::CommSettings& settings,
-  sick::datastructure::ApplicationName& application_name)
+void SickSafetyscannersBase::asyncRequestTypeCode(const sick::datastructure::CommSettings& settings,
+                                                  sick::datastructure::TypeCode& type_code,
+                                                  AsyncCompleteHandler handler)
 {
-  startTCPConnection(settings);
-  requestApplicationNameInColaSession(application_name);
-  stopTCPConnection();
-}
-void SickSafetyscannersBase::requestFieldData(
-  const datastructure::CommSettings& settings,
-  std::vector<sick::datastructure::FieldData>& field_data)
-{
-  startTCPConnection(settings);
-  requestFieldDataInColaSession(field_data);
-  stopTCPConnection();
+  detail::processCola2Command<sick::cola2::TypeCodeVariableCommand>( *m_io_service_ptr, settings, std::ref(type_code), handler );
 }
 
-void SickSafetyscannersBase::requestMonitoringCases(
-  const datastructure::CommSettings& settings,
-  std::vector<sick::datastructure::MonitoringCaseData>& monitoring_cases)
+void SickSafetyscannersBase::requestApplicationName(const datastructure::CommSettings& settings,
+                                                    sick::datastructure::ApplicationName& application_name)
 {
-  startTCPConnection(settings);
-  requestMonitoringCaseDataInColaSession(monitoring_cases);
-  stopTCPConnection();
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncRequestApplicationName(settings, application_name, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
+
+  ROS_INFO("Application name: %s", application_name.getApplicationName().c_str());
 }
 
-void SickSafetyscannersBase::requestDeviceName(const datastructure::CommSettings& settings,
-                                               datastructure::DeviceName& device_name)
+void SickSafetyscannersBase::asyncRequestApplicationName(const sick::datastructure::CommSettings& settings,
+                                                         sick::datastructure::ApplicationName& application_name,
+                                                         AsyncCompleteHandler handler)
 {
-  startTCPConnection(settings);
-  requestDeviceNameInColaSession(device_name);
-  stopTCPConnection();
+  detail::processCola2Command<sick::cola2::ApplicationNameVariableCommand>( *m_io_service_ptr, settings, std::ref(application_name), handler );
 }
 
 void SickSafetyscannersBase::requestSerialNumber(const datastructure::CommSettings& settings,
                                                  datastructure::SerialNumber& serial_number)
 {
-  startTCPConnection(settings);
-  requestSerialNumberInColaSession(serial_number);
-  stopTCPConnection();
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncRequestSerialNumber(settings, serial_number, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
+
+  ROS_INFO("Serial Number: %s", serial_number.getSerialNumber().c_str());
+}
+
+void SickSafetyscannersBase::asyncRequestSerialNumber(const sick::datastructure::CommSettings& settings,
+                                                      sick::datastructure::SerialNumber& serial_number,
+                                                      AsyncCompleteHandler handler)
+{
+  detail::processCola2Command<sick::cola2::SerialNumberVariableCommand>( *m_io_service_ptr, settings, std::ref(serial_number), handler );
+}
+
+void SickSafetyscannersBase::requestFirmwareVersion(const datastructure::CommSettings& settings,
+                                                    datastructure::FirmwareVersion& firmware_version)
+{
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncRequestFirmwareVersion(settings, firmware_version, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
+
+  ROS_INFO("Firmware Version: %s", firmware_version.getFirmwareVersion().c_str());
+}
+
+void SickSafetyscannersBase::asyncRequestFirmwareVersion(const sick::datastructure::CommSettings& settings,
+                                                         sick::datastructure::FirmwareVersion& firmware_version,
+                                                         AsyncCompleteHandler handler)
+{
+  detail::processCola2Command<sick::cola2::FirmwareVersionVariableCommand>( *m_io_service_ptr, settings, std::ref(firmware_version), handler );
 }
 
 void SickSafetyscannersBase::requestOrderNumber(const datastructure::CommSettings& settings,
                                                 datastructure::OrderNumber& order_number)
 {
-  startTCPConnection(settings);
-  requestOrderNumberInColaSession(order_number);
-  stopTCPConnection();
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncRequestOrderNumber(settings, order_number, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
+
+  ROS_INFO("Order Number: %s", order_number.getOrderNumber().c_str());
+}
+
+void SickSafetyscannersBase::asyncRequestOrderNumber(const datastructure::CommSettings& settings,
+                                                     datastructure::OrderNumber& order_number,
+                                                     AsyncCompleteHandler handler)
+{
+  detail::processCola2Command<sick::cola2::OrderNumberVariableCommand>( *m_io_service_ptr, settings, std::ref(order_number), handler );
 }
 
 void SickSafetyscannersBase::requestProjectName(const datastructure::CommSettings& settings,
                                                 datastructure::ProjectName& project_name)
 {
-  startTCPConnection(settings);
-  requestProjectNameInColaSession(project_name);
-  stopTCPConnection();
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncRequestProjectName(settings, project_name, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
+
+  ROS_INFO("Project Name: %s", project_name.getProjectName().c_str());
+}
+
+void SickSafetyscannersBase::asyncRequestProjectName(const datastructure::CommSettings& settings,
+                                                     datastructure::ProjectName& project_name,
+                                                     AsyncCompleteHandler handler)
+{
+  detail::processCola2Command<sick::cola2::ProjectNameVariableCommand>( *m_io_service_ptr, settings, std::ref(project_name), handler );
 }
 
 void SickSafetyscannersBase::requestUserName(const datastructure::CommSettings& settings,
                                              datastructure::UserName& user_name)
 {
-  startTCPConnection(settings);
-  requestUserNameInColaSession(user_name);
-  stopTCPConnection();
-}
-void SickSafetyscannersBase::requestFirmwareVersion(
-  const datastructure::CommSettings& settings, datastructure::FirmwareVersion& firmware_version)
-{
-  startTCPConnection(settings);
-  requestFirmwareVersionInColaSession(firmware_version);
-  stopTCPConnection();
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncRequestUserName(settings, user_name, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
+
+  ROS_INFO("User Name: %s", user_name.getUserName().c_str());
 }
 
-void SickSafetyscannersBase::requestPersistentConfig(const datastructure::CommSettings& settings,
-                                                     sick::datastructure::ConfigData& config_data)
+void SickSafetyscannersBase::asyncRequestUserName(const datastructure::CommSettings& settings,
+                                                  datastructure::UserName& user_name,
+                                                  AsyncCompleteHandler handler)
 {
-  startTCPConnection(settings);
-  requestPersistentConfigInColaSession(config_data);
-  stopTCPConnection();
+  detail::processCola2Command<sick::cola2::UserNameVariableCommand>( *m_io_service_ptr, settings, std::ref(user_name), handler );
 }
 
-void SickSafetyscannersBase::requestConfigMetadata(
-  const datastructure::CommSettings& settings, sick::datastructure::ConfigMetadata& config_metadata)
+void SickSafetyscannersBase::requestConfigMetadata(const datastructure::CommSettings& settings,
+                                                   sick::datastructure::ConfigMetadata& config_metadata)
 {
-  startTCPConnection(settings);
-  requestConfigMetadataInColaSession(config_metadata);
-  stopTCPConnection();
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncRequestConfigMetadata(settings, config_metadata, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
 }
 
-void SickSafetyscannersBase::requestStatusOverview(
-  const datastructure::CommSettings& settings, sick::datastructure::StatusOverview& status_overview)
+void SickSafetyscannersBase::asyncRequestConfigMetadata(const datastructure::CommSettings& settings,
+                                                        datastructure::ConfigMetadata& config_metadata,
+                                                        AsyncCompleteHandler handler)
 {
-  startTCPConnection(settings);
-  requestStatusOverviewInColaSession(status_overview);
-  stopTCPConnection();
+  detail::processCola2Command<sick::cola2::ConfigMetadataVariableCommand>( *m_io_service_ptr, settings, std::ref(config_metadata), handler );
+}
+
+void SickSafetyscannersBase::requestStatusOverview(const datastructure::CommSettings& settings,
+                                                   sick::datastructure::StatusOverview& status_overview)
+{
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncRequestStatusOverview(settings, status_overview, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
+}
+
+void SickSafetyscannersBase::asyncRequestStatusOverview(const datastructure::CommSettings& settings,
+                                                        datastructure::StatusOverview& status_overview,
+                                                        AsyncCompleteHandler handler)
+{
+  detail::processCola2Command<sick::cola2::StatusOverviewVariableCommand>( *m_io_service_ptr, settings, std::ref(status_overview), handler );
 }
 
 void SickSafetyscannersBase::requestDeviceStatus(const datastructure::CommSettings& settings,
                                                  sick::datastructure::DeviceStatus& device_status)
 {
-  startTCPConnection(settings);
-  requestDeviceStatusInColaSession(device_status);
-  stopTCPConnection();
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncRequestDeviceStatus(settings, device_status, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
 }
 
-void SickSafetyscannersBase::requestRequiredUserAction(
-  const datastructure::CommSettings& settings,
-  sick::datastructure::RequiredUserAction& required_user_action)
+void SickSafetyscannersBase::asyncRequestDeviceStatus(const datastructure::CommSettings& settings,
+                                                      datastructure::DeviceStatus& device_status,
+                                                      AsyncCompleteHandler handler)
 {
-  startTCPConnection(settings);
-  requestRequiredUserActionInColaSession(required_user_action);
-  stopTCPConnection();
+  detail::processCola2Command<sick::cola2::DeviceStatusVariableCommand>( *m_io_service_ptr, settings, std::ref(device_status), handler );
 }
 
-void SickSafetyscannersBase::startTCPConnection(const sick::datastructure::CommSettings& settings)
+void SickSafetyscannersBase::requestRequiredUserAction(const datastructure::CommSettings& settings,
+                                                       sick::datastructure::RequiredUserAction& required_user_action)
 {
-  std::shared_ptr<sick::communication::AsyncTCPClient> async_tcp_client =
-    std::make_shared<sick::communication::AsyncTCPClient>(
-      boost::bind(&SickSafetyscannersBase::processTCPPacket, this, _1),
-      boost::ref(*m_io_service_ptr),
-      settings.getSensorIp(),
-      settings.getSensorTcpPort());
-  async_tcp_client->doConnect();
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
 
-  m_session_ptr.reset();
-  m_session_ptr = std::make_shared<sick::cola2::Cola2Session>(async_tcp_client);
+  asyncRequestRequiredUserAction(settings, required_user_action, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
 
-  m_session_ptr->open();
+  promise->get_future().wait();
 }
 
-void SickSafetyscannersBase::changeCommSettingsInColaSession(
-  const datastructure::CommSettings& settings)
+void SickSafetyscannersBase::asyncRequestRequiredUserAction(const datastructure::CommSettings& settings,
+                                                            datastructure::RequiredUserAction& required_user_action,
+                                                            AsyncCompleteHandler handler)
 {
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::ChangeCommSettingsCommand>(boost::ref(*m_session_ptr), settings);
-  m_session_ptr->executeCommand(command_ptr);
+  detail::processCola2Command<sick::cola2::RequiredUserActionVariableCommand>( *m_io_service_ptr, settings, std::ref(required_user_action), handler );
 }
 
-void SickSafetyscannersBase::requestFieldDataInColaSession(
-  std::vector<sick::datastructure::FieldData>& fields)
+void SickSafetyscannersBase::requestDeviceName(const datastructure::CommSettings& settings,
+                                               datastructure::DeviceName& device_name)
 {
-  sick::datastructure::ConfigData config_data;
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
 
-  /*sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::MeasurementPersistentConfigVariableCommand>(
-      boost::ref(*m_session_ptr), pers_config_data);
-  m_session_ptr->executeCommand(command_ptr);
-*/
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::MeasurementCurrentConfigVariableCommand>(
-      boost::ref(*m_session_ptr), config_data);
-  m_session_ptr->executeCommand(command_ptr);
-  /*
-    command_ptr = std::make_shared<sick::cola2::MonitoringCaseTableHeaderVariableCommand>(
-      boost::ref(*m_session_ptr), common_field_data);
-    m_session_ptr->executeCommand(command_ptr);
-  */
-  for (int i = 0; i < 128; i++)
-  {
-    sick::datastructure::FieldData field_data;
+  asyncRequestDeviceName(settings, device_name, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
 
-    command_ptr = std::make_shared<sick::cola2::FieldHeaderVariableCommand>(
-      boost::ref(*m_session_ptr), field_data, i);
-    m_session_ptr->executeCommand(command_ptr);
+  promise->get_future().wait();
 
-    if (field_data.getIsValid())
-    {
-      command_ptr = std::make_shared<sick::cola2::FieldGeometryVariableCommand>(
-        boost::ref(*m_session_ptr), field_data, i);
-      m_session_ptr->executeCommand(command_ptr);
-
-      field_data.setStartAngleDegrees(config_data.getDerivedStartAngle());
-      field_data.setAngularBeamResolutionDegrees(config_data.getDerivedAngularBeamResolution());
-
-      fields.push_back(field_data);
-    }
-    else if (i > 0) // index 0 is reserved for contour data
-    {
-      break; // skip other requests after first invalid
-    }
-  }
-}
-
-void SickSafetyscannersBase::requestMonitoringCaseDataInColaSession(
-  std::vector<sick::datastructure::MonitoringCaseData>& monitoring_cases)
-{
-  sick::cola2::Cola2Session::CommandPtr command_ptr;
-  for (int i = 0; i < 254; i++)
-  {
-    sick::datastructure::MonitoringCaseData monitoring_case_data;
-
-    command_ptr = std::make_shared<sick::cola2::MonitoringCaseVariableCommand>(
-      boost::ref(*m_session_ptr), monitoring_case_data, i);
-    m_session_ptr->executeCommand(command_ptr);
-    if (monitoring_case_data.getIsValid())
-    {
-      monitoring_cases.push_back(monitoring_case_data);
-    }
-    else
-    {
-      break; // skip other requests after first invalid
-    }
-  }
-}
-
-void SickSafetyscannersBase::findSensorInColaSession(uint16_t blink_time)
-{
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::FindMeCommand>(boost::ref(*m_session_ptr), blink_time);
-  m_session_ptr->executeCommand(command_ptr);
-}
-
-void SickSafetyscannersBase::requestDeviceNameInColaSession(datastructure::DeviceName& device_name)
-{
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::DeviceNameVariableCommand>(boost::ref(*m_session_ptr),
-                                                             device_name);
-  m_session_ptr->executeCommand(command_ptr);
   ROS_INFO("Device name: %s", device_name.getDeviceName().c_str());
 }
 
-
-void SickSafetyscannersBase::requestApplicationNameInColaSession(
-  datastructure::ApplicationName& application_name)
+void SickSafetyscannersBase::asyncRequestDeviceName(const sick::datastructure::CommSettings& settings,
+                                                    datastructure::DeviceName& device_name,
+                                                    AsyncCompleteHandler handler)
 {
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::ApplicationNameVariableCommand>(boost::ref(*m_session_ptr),
-                                                                  application_name);
-  m_session_ptr->executeCommand(command_ptr);
-  ROS_INFO("Application name: %s", application_name.getApplicationName().c_str());
+  detail::processCola2Command<sick::cola2::DeviceNameVariableCommand>( *m_io_service_ptr, settings, std::ref(device_name), handler );
 }
 
-void SickSafetyscannersBase::requestSerialNumberInColaSession(
-  datastructure::SerialNumber& serial_number)
+void SickSafetyscannersBase::requestPersistentConfig(const datastructure::CommSettings& settings,
+                                                     sick::datastructure::ConfigData& config_data)
 {
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::SerialNumberVariableCommand>(boost::ref(*m_session_ptr),
-                                                               serial_number);
-  m_session_ptr->executeCommand(command_ptr);
-  ROS_INFO("Serial Number: %s", serial_number.getSerialNumber().c_str());
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncRequestPersistentConfig(settings, config_data, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
 }
 
-void SickSafetyscannersBase::requestFirmwareVersionInColaSession(
-  datastructure::FirmwareVersion& firmware_version)
+void SickSafetyscannersBase::asyncRequestPersistentConfig(const datastructure::CommSettings& settings,
+                                                          sick::datastructure::ConfigData& config_data,
+                                                          AsyncCompleteHandler handler)
 {
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::FirmwareVersionVariableCommand>(boost::ref(*m_session_ptr),
-                                                                  firmware_version);
-  m_session_ptr->executeCommand(command_ptr);
-  ROS_INFO("Firmware Version: %s", firmware_version.getFirmwareVersion().c_str());
+  detail::processCola2Command<sick::cola2::MeasurementPersistentConfigVariableCommand>( *m_io_service_ptr, settings, std::ref(config_data), handler );
 }
 
-void SickSafetyscannersBase::requestTypeCodeInColaSession(sick::datastructure::TypeCode& type_code)
+
+
+
+
+void SickSafetyscannersBase::requestFieldData(const datastructure::CommSettings& settings,
+                                              std::vector<sick::datastructure::FieldData>& field_data)
 {
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::TypeCodeVariableCommand>(boost::ref(*m_session_ptr), type_code);
-  m_session_ptr->executeCommand(command_ptr);
-  ROS_INFO("Type Code: %s", type_code.getTypeCode().c_str());
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncRequestFieldData(settings, field_data, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
 }
 
-void SickSafetyscannersBase::requestOrderNumberInColaSession(
-  sick::datastructure::OrderNumber& order_number)
+void SickSafetyscannersBase::asyncRequestFieldData(const sick::datastructure::CommSettings& settings,
+                                                   std::vector<sick::datastructure::FieldData>& field_data,
+                                                   AsyncCompleteHandler handler)
 {
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::OrderNumberVariableCommand>(boost::ref(*m_session_ptr),
-                                                              order_number);
-  m_session_ptr->executeCommand(command_ptr);
-  ROS_INFO("Order Number: %s", order_number.getOrderNumber().c_str());
+  auto fd = std::ref(field_data);
+
+  detail::openCola2Session(*m_io_service_ptr, settings, [fd, handler](const boost::system::error_code& ec, detail::Cola2SessionPtr session) {
+    if ( ec )
+    {
+      handler( ec );
+      return;
+    }
+
+    detail::requestFieldData( session, fd, [session, handler](const boost::system::error_code& ec) {
+      AsyncCompleteHandler nextHandler = handler;
+      if ( ec )
+      {
+        nextHandler( ec );
+        nextHandler = AsyncCompleteHandler();
+      }
+
+      session->close( [session, nextHandler](const boost::system::error_code& ec) {
+        session->doDisconnect();
+
+        if ( nextHandler )
+        {
+          nextHandler( ec );
+        }
+      });
+    });
+  });
 }
 
-void SickSafetyscannersBase::requestProjectNameInColaSession(
-  sick::datastructure::ProjectName& project_name)
+
+void SickSafetyscannersBase::requestMonitoringCases(const datastructure::CommSettings& settings,
+                                                    std::vector<sick::datastructure::MonitoringCaseData>& monitoring_cases)
 {
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::ProjectNameVariableCommand>(boost::ref(*m_session_ptr),
-                                                              project_name);
-  m_session_ptr->executeCommand(command_ptr);
-  ROS_INFO("Project Name: %s", project_name.getProjectName().c_str());
+  CompletePromisePtr promise = std::make_shared<CompletePromise>();
+
+  asyncRequestMonitoringCases(settings, monitoring_cases, [promise](const boost::system::error_code& ec) {
+    promise->set_value(ec);
+  });
+
+  promise->get_future().wait();
 }
 
-void SickSafetyscannersBase::requestUserNameInColaSession(sick::datastructure::UserName& user_name)
-{
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::UserNameVariableCommand>(boost::ref(*m_session_ptr), user_name);
-  m_session_ptr->executeCommand(command_ptr);
-  ROS_INFO("User Name: %s", user_name.getUserName().c_str());
-}
 
-void SickSafetyscannersBase::requestConfigMetadataInColaSession(
-  sick::datastructure::ConfigMetadata& config_metadata)
+void SickSafetyscannersBase::asyncRequestMonitoringCases(const sick::datastructure::CommSettings& settings,
+                                                         std::vector<sick::datastructure::MonitoringCaseData>& monitoring_cases,
+                                                         AsyncCompleteHandler handler)
 {
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::ConfigMetadataVariableCommand>(boost::ref(*m_session_ptr),
-                                                                 config_metadata);
-  m_session_ptr->executeCommand(command_ptr);
-}
+  auto mc = std::ref(monitoring_cases);
 
-void SickSafetyscannersBase::requestStatusOverviewInColaSession(
-  sick::datastructure::StatusOverview& status_overview)
-{
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::StatusOverviewVariableCommand>(boost::ref(*m_session_ptr),
-                                                                 status_overview);
-  m_session_ptr->executeCommand(command_ptr);
-}
+  detail::openCola2Session(*m_io_service_ptr, settings, [mc, handler](const boost::system::error_code& ec, detail::Cola2SessionPtr session) {
+    if ( ec )
+    {
+      handler( ec );
+      return;
+    }
 
-void SickSafetyscannersBase::requestDeviceStatusInColaSession(
-  sick::datastructure::DeviceStatus& device_status)
-{
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::DeviceStatusVariableCommand>(boost::ref(*m_session_ptr),
-                                                               device_status);
-  m_session_ptr->executeCommand(command_ptr);
-}
+    detail::requestNextMonitoringCase( 0, session, mc, [session, handler](const boost::system::error_code& ec) {
+      AsyncCompleteHandler nextHandler = handler;
+      if ( ec )
+      {
+        nextHandler( ec );
+        nextHandler = AsyncCompleteHandler();
+      }
 
-void SickSafetyscannersBase::requestRequiredUserActionInColaSession(
-  sick::datastructure::RequiredUserAction& required_user_action)
-{
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::RequiredUserActionVariableCommand>(boost::ref(*m_session_ptr),
-                                                                     required_user_action);
-  m_session_ptr->executeCommand(command_ptr);
-}
+      session->close( [session, nextHandler](const boost::system::error_code& ec) {
+        session->doDisconnect();
 
-void SickSafetyscannersBase::requestPersistentConfigInColaSession(
-  sick::datastructure::ConfigData& config_data)
-{
-  sick::cola2::Cola2Session::CommandPtr command_ptr =
-    std::make_shared<sick::cola2::MeasurementPersistentConfigVariableCommand>(
-      boost::ref(*m_session_ptr), config_data);
-  m_session_ptr->executeCommand(command_ptr);
-}
-
-void SickSafetyscannersBase::stopTCPConnection()
-{
-  m_session_ptr->close();
-  m_session_ptr->doDisconnect();
+        if ( nextHandler )
+        {
+          nextHandler( ec );
+        }
+      });
+    });
+  });
 }
 
 void SickSafetyscannersBase::processUDPPacket(const sick::datastructure::PacketBuffer& buffer)

--- a/src/cola2/ApplicationNameVariableCommand.cpp
+++ b/src/cola2/ApplicationNameVariableCommand.cpp
@@ -45,8 +45,6 @@ ApplicationNameVariableCommand::ApplicationNameVariableCommand(
   : VariableCommand(session, 33)
   , m_application_name(application_name)
 {
-  m_application_name_parser_ptr =
-    std::make_shared<sick::data_processing::ParseApplicationNameData>();
 }
 
 bool ApplicationNameVariableCommand::canBeExecutedWithoutSessionID() const
@@ -60,8 +58,8 @@ bool ApplicationNameVariableCommand::processReply()
   {
     return false;
   }
-  m_application_name_parser_ptr->parseTCPSequence(getDataVector(), m_application_name);
-  return true;
+
+  return sick::data_processing::ParseApplicationNameData::parseTCPSequence(getDataVector(), m_application_name);
 }
 
 

--- a/src/cola2/ChangeCommSettingsCommand.cpp
+++ b/src/cola2/ChangeCommSettingsCommand.cpp
@@ -123,13 +123,13 @@ void ChangeCommSettingsCommand::writeFrequencyToDataPtr(
 void ChangeCommSettingsCommand::writeStartAngleToDataPtr(
   std::vector<uint8_t>::iterator data_ptr) const
 {
-  read_write_helper::writeUint32LittleEndian(data_ptr + 16, m_settings.getStartAngle());
+  read_write_helper::writeInt32LittleEndian(data_ptr + 16, m_settings.getStartAngle());
 }
 
 void ChangeCommSettingsCommand::writeEndAngleToDataPtr(
   std::vector<uint8_t>::iterator data_ptr) const
 {
-  read_write_helper::writeUint32LittleEndian(data_ptr + 20, m_settings.getEndAngle());
+  read_write_helper::writeInt32LittleEndian(data_ptr + 20, m_settings.getEndAngle());
 }
 
 void ChangeCommSettingsCommand::writeFeaturesToDataPtr(

--- a/src/cola2/CloseSession.cpp
+++ b/src/cola2/CloseSession.cpp
@@ -32,11 +32,12 @@
  */
 //----------------------------------------------------------------------
 
-
-#include <sick_safetyscanners_base/cola2/CloseSession.h>
+#include <sick_safetyscanners_base/logging/logging_wrapper.h>
 
 #include <sick_safetyscanners_base/cola2/Cola2Session.h>
 #include <sick_safetyscanners_base/cola2/Command.h>
+
+#include <sick_safetyscanners_base/cola2/CloseSession.h>
 
 namespace sick {
 namespace cola2 {

--- a/src/cola2/Cola2Session.cpp
+++ b/src/cola2/Cola2Session.cpp
@@ -44,7 +44,6 @@ Cola2Session::Cola2Session(const std::shared_ptr<communication::AsyncTCPClient>&
 {
   m_async_tcp_client_ptr->setPacketHandler(boost::bind(&Cola2Session::processPacket, this, _1));
   m_packet_merger_ptr = std::make_shared<sick::data_processing::TCPPacketMerger>();
-  m_tcp_parser_ptr    = std::make_shared<sick::data_processing::ParseTCPPacket>();
 }
 
 bool Cola2Session::open()
@@ -108,7 +107,7 @@ bool Cola2Session::addPacketToMerger(const sick::datastructure::PacketBuffer& pa
 {
   if (m_packet_merger_ptr->isEmpty() || m_packet_merger_ptr->isComplete())
   {
-    m_packet_merger_ptr->setTargetSize(m_tcp_parser_ptr->getExpectedPacketLength(packet));
+    m_packet_merger_ptr->setTargetSize( sick::data_processing::ParseTCPPacket::getExpectedPacketLength(packet));
   }
   m_packet_merger_ptr->addTCPPacket(packet);
   return true;
@@ -128,7 +127,7 @@ bool Cola2Session::checkIfPacketIsCompleteAndOtherwiseListenForMorePackets()
 bool Cola2Session::startProcessingAndRemovePendingCommandAfterwards(
   const sick::datastructure::PacketBuffer& packet)
 {
-  uint16_t request_id = m_tcp_parser_ptr->getRequestID(packet);
+  uint16_t request_id = sick::data_processing::ParseTCPPacket::getRequestID(packet);
   CommandPtr pending_command;
   if (findCommand(request_id, pending_command))
   {

--- a/src/cola2/Cola2Session.cpp
+++ b/src/cola2/Cola2Session.cpp
@@ -42,42 +42,54 @@ Cola2Session::Cola2Session(const std::shared_ptr<communication::AsyncTCPClient>&
   , m_session_id(0)
   , m_last_request_id(0)
 {
-  m_async_tcp_client_ptr->setPacketHandler(boost::bind(&Cola2Session::processPacket, this, _1));
   m_packet_merger_ptr = std::make_shared<sick::data_processing::TCPPacketMerger>();
 }
 
-bool Cola2Session::open()
+Cola2Session::~Cola2Session()
+{
+//  std::clog << "Descruct Cola2Session" << std::endl;
+}
+
+bool Cola2Session::open(CompleteHandler handler)
 {
   CommandPtr command_ptr = std::make_shared<CreateSession>(boost::ref(*this));
-  return executeCommand(command_ptr);
+  return executeCommand(command_ptr, handler);
 }
 
-bool Cola2Session::close()
+bool Cola2Session::close(CompleteHandler handler)
 {
   CommandPtr command_ptr = std::make_shared<CloseSession>(boost::ref(*this));
-  return executeCommand(command_ptr);
+  return executeCommand(command_ptr, handler);
 }
 
-void Cola2Session::doDisconnect()
+boost::system::error_code Cola2Session::doDisconnect()
 {
-  m_async_tcp_client_ptr->doDisconnect();
+  return m_async_tcp_client_ptr->doDisconnect();
 }
 
-bool Cola2Session::executeCommand(const CommandPtr& command)
+bool Cola2Session::executeCommand(const CommandPtr& command, CompleteHandler handler)
 {
   addCommand(command->getRequestID(), command);
-  sendTelegramAndListenForAnswer(command);
+  sendTelegramAndListenForAnswer(command, handler );
   return true;
 }
 
-bool Cola2Session::sendTelegramAndListenForAnswer(const CommandPtr& command)
+void Cola2Session::sendTelegramAndListenForAnswer(const CommandPtr& command, CompleteHandler handler)
 {
-  command->lockExecutionMutex(); // lock
   std::vector<uint8_t> telegram;
   telegram = command->constructTelegram(telegram);
-  m_async_tcp_client_ptr->doSendAndReceive(telegram);
-  command->waitForCompletion(); // scooped locked to wait, unlocked on data processing
-  return true;
+
+  m_async_tcp_client_ptr->send(telegram, [this, handler]( boost::system::error_code ec ) {
+    if ( ec )
+    {
+      handler(ec);
+      return;
+    }
+
+    m_async_tcp_client_ptr->readSome(std::bind(&Cola2Session::processPacket,
+                                               this, std::placeholders::_1, std::placeholders::_2,
+                                               handler));
+  });
 }
 
 
@@ -91,16 +103,33 @@ void Cola2Session::setSessionID(const uint32_t& session_id)
   m_session_id = session_id;
 }
 
-void Cola2Session::processPacket(const datastructure::PacketBuffer& packet)
+void Cola2Session::processPacket(const datastructure::PacketBuffer& packet,
+                                 const boost::system::error_code& ec,
+                                 CompleteHandler handler)
 {
-  addPacketToMerger(packet);
-  if (!checkIfPacketIsCompleteAndOtherwiseListenForMorePackets())
+  if ( ec )
   {
+    handler( ec );
     return;
   }
-  sick::datastructure::PacketBuffer deployed_packet =
-    m_packet_merger_ptr->getDeployedPacketBuffer();
-  startProcessingAndRemovePendingCommandAfterwards(deployed_packet);
+
+  addPacketToMerger(packet);
+
+  // checkIfPacketIsCompleteAndOtherwiseListenForMorePackets
+  if (m_packet_merger_ptr->isComplete())
+  {
+    sick::datastructure::PacketBuffer deployed_packet =
+      m_packet_merger_ptr->getDeployedPacketBuffer();
+
+    startProcessingAndRemovePendingCommandAfterwards(deployed_packet);
+    handler( ec );
+  }
+  else
+  {
+    m_async_tcp_client_ptr->readSome(std::bind(&Cola2Session::processPacket,
+                                               this, std::placeholders::_1, std::placeholders::_2,
+                                               handler));
+  }
 }
 
 bool Cola2Session::addPacketToMerger(const sick::datastructure::PacketBuffer& packet)
@@ -109,62 +138,66 @@ bool Cola2Session::addPacketToMerger(const sick::datastructure::PacketBuffer& pa
   {
     m_packet_merger_ptr->setTargetSize( sick::data_processing::ParseTCPPacket::getExpectedPacketLength(packet));
   }
+
   m_packet_merger_ptr->addTCPPacket(packet);
+
   return true;
 }
-
-bool Cola2Session::checkIfPacketIsCompleteAndOtherwiseListenForMorePackets()
-{
-  if (!m_packet_merger_ptr->isComplete())
-  {
-    m_async_tcp_client_ptr->initiateReceive();
-    return false;
-  }
-  return true;
-}
-
 
 bool Cola2Session::startProcessingAndRemovePendingCommandAfterwards(
   const sick::datastructure::PacketBuffer& packet)
 {
   uint16_t request_id = sick::data_processing::ParseTCPPacket::getRequestID(packet);
   CommandPtr pending_command;
+
   if (findCommand(request_id, pending_command))
   {
     pending_command->processReplyBase(*packet.getBuffer());
     removeCommand(request_id);
   }
+
   return true;
 }
 
 bool Cola2Session::addCommand(const uint16_t& request_id, const CommandPtr& command)
 {
+  boost::mutex::scoped_lock lock(m_pending_commands_map_mutex);
+
   if (m_pending_commands_map.find(request_id) != m_pending_commands_map.end())
   {
     return false;
   }
+
   m_pending_commands_map[request_id] = command;
+
   return true;
 }
 
 bool Cola2Session::findCommand(const uint16_t& request_id, CommandPtr& command)
 {
+  boost::mutex::scoped_lock lock(m_pending_commands_map_mutex);
+
   if (m_pending_commands_map.find(request_id) == m_pending_commands_map.end())
   {
     return false;
   }
   command = m_pending_commands_map[request_id];
+
   return true;
 }
 
 bool Cola2Session::removeCommand(const uint16_t& request_id)
 {
+  boost::mutex::scoped_lock lock(m_pending_commands_map_mutex);
+
   auto it = m_pending_commands_map.find(request_id);
   if (it == m_pending_commands_map.end())
   {
     return false;
   }
+
   m_pending_commands_map.erase(it);
+
   return true;
 }
 

--- a/src/cola2/Cola2Session.cpp
+++ b/src/cola2/Cola2Session.cpp
@@ -42,43 +42,54 @@ Cola2Session::Cola2Session(const std::shared_ptr<communication::AsyncTCPClient>&
   , m_session_id(0)
   , m_last_request_id(0)
 {
-  m_async_tcp_client_ptr->setPacketHandler(boost::bind(&Cola2Session::processPacket, this, _1));
   m_packet_merger_ptr = std::make_shared<sick::data_processing::TCPPacketMerger>();
-  m_tcp_parser_ptr    = std::make_shared<sick::data_processing::ParseTCPPacket>();
 }
 
-bool Cola2Session::open()
+Cola2Session::~Cola2Session()
+{
+//  std::clog << "Descruct Cola2Session" << std::endl;
+}
+
+bool Cola2Session::open(CompleteHandler handler)
 {
   CommandPtr command_ptr = std::make_shared<CreateSession>(boost::ref(*this));
-  return executeCommand(command_ptr);
+  return executeCommand(command_ptr, handler);
 }
 
-bool Cola2Session::close()
+bool Cola2Session::close(CompleteHandler handler)
 {
   CommandPtr command_ptr = std::make_shared<CloseSession>(boost::ref(*this));
-  return executeCommand(command_ptr);
+  return executeCommand(command_ptr, handler);
 }
 
-void Cola2Session::doDisconnect()
+boost::system::error_code Cola2Session::doDisconnect()
 {
-  m_async_tcp_client_ptr->doDisconnect();
+  return m_async_tcp_client_ptr->doDisconnect();
 }
 
-bool Cola2Session::executeCommand(const CommandPtr& command)
+bool Cola2Session::executeCommand(const CommandPtr& command, CompleteHandler handler)
 {
   addCommand(command->getRequestID(), command);
-  sendTelegramAndListenForAnswer(command);
+  sendTelegramAndListenForAnswer(command, handler );
   return true;
 }
 
-bool Cola2Session::sendTelegramAndListenForAnswer(const CommandPtr& command)
+void Cola2Session::sendTelegramAndListenForAnswer(const CommandPtr& command, CompleteHandler handler)
 {
-  command->lockExecutionMutex(); // lock
   std::vector<uint8_t> telegram;
   telegram = command->constructTelegram(telegram);
-  m_async_tcp_client_ptr->doSendAndReceive(telegram);
-  command->waitForCompletion(); // scooped locked to wait, unlocked on data processing
-  return true;
+
+  m_async_tcp_client_ptr->send(telegram, [this, handler]( boost::system::error_code ec ) {
+    if ( ec )
+    {
+      handler(ec);
+      return;
+    }
+
+    m_async_tcp_client_ptr->readSome(std::bind(&Cola2Session::processPacket,
+                                               this, std::placeholders::_1, std::placeholders::_2,
+                                               handler));
+  });
 }
 
 
@@ -92,80 +103,101 @@ void Cola2Session::setSessionID(const uint32_t& session_id)
   m_session_id = session_id;
 }
 
-void Cola2Session::processPacket(const datastructure::PacketBuffer& packet)
+void Cola2Session::processPacket(const datastructure::PacketBuffer& packet,
+                                 const boost::system::error_code& ec,
+                                 CompleteHandler handler)
 {
-  addPacketToMerger(packet);
-  if (!checkIfPacketIsCompleteAndOtherwiseListenForMorePackets())
+  if ( ec )
   {
+    handler( ec );
     return;
   }
-  sick::datastructure::PacketBuffer deployed_packet =
-    m_packet_merger_ptr->getDeployedPacketBuffer();
-  startProcessingAndRemovePendingCommandAfterwards(deployed_packet);
+
+  addPacketToMerger(packet);
+
+  // checkIfPacketIsCompleteAndOtherwiseListenForMorePackets
+  if (m_packet_merger_ptr->isComplete())
+  {
+    sick::datastructure::PacketBuffer deployed_packet =
+      m_packet_merger_ptr->getDeployedPacketBuffer();
+
+    startProcessingAndRemovePendingCommandAfterwards(deployed_packet);
+    handler( ec );
+  }
+  else
+  {
+    m_async_tcp_client_ptr->readSome(std::bind(&Cola2Session::processPacket,
+                                               this, std::placeholders::_1, std::placeholders::_2,
+                                               handler));
+  }
 }
 
 bool Cola2Session::addPacketToMerger(const sick::datastructure::PacketBuffer& packet)
 {
   if (m_packet_merger_ptr->isEmpty() || m_packet_merger_ptr->isComplete())
   {
-    m_packet_merger_ptr->setTargetSize(m_tcp_parser_ptr->getExpectedPacketLength(packet));
+    m_packet_merger_ptr->setTargetSize( sick::data_processing::ParseTCPPacket::getExpectedPacketLength(packet));
   }
+
   m_packet_merger_ptr->addTCPPacket(packet);
+
   return true;
 }
-
-bool Cola2Session::checkIfPacketIsCompleteAndOtherwiseListenForMorePackets()
-{
-  if (!m_packet_merger_ptr->isComplete())
-  {
-    m_async_tcp_client_ptr->initiateReceive();
-    return false;
-  }
-  return true;
-}
-
 
 bool Cola2Session::startProcessingAndRemovePendingCommandAfterwards(
   const sick::datastructure::PacketBuffer& packet)
 {
-  uint16_t request_id = m_tcp_parser_ptr->getRequestID(packet);
+  uint16_t request_id = sick::data_processing::ParseTCPPacket::getRequestID(packet);
   CommandPtr pending_command;
+
   if (findCommand(request_id, pending_command))
   {
     pending_command->processReplyBase(*packet.getBuffer());
     removeCommand(request_id);
   }
+
   return true;
 }
 
 bool Cola2Session::addCommand(const uint16_t& request_id, const CommandPtr& command)
 {
+  boost::mutex::scoped_lock lock(m_pending_commands_map_mutex);
+
   if (m_pending_commands_map.find(request_id) != m_pending_commands_map.end())
   {
     return false;
   }
+
   m_pending_commands_map[request_id] = command;
+
   return true;
 }
 
 bool Cola2Session::findCommand(const uint16_t& request_id, CommandPtr& command)
 {
+  boost::mutex::scoped_lock lock(m_pending_commands_map_mutex);
+
   if (m_pending_commands_map.find(request_id) == m_pending_commands_map.end())
   {
     return false;
   }
   command = m_pending_commands_map[request_id];
+
   return true;
 }
 
 bool Cola2Session::removeCommand(const uint16_t& request_id)
 {
+  boost::mutex::scoped_lock lock(m_pending_commands_map_mutex);
+
   auto it = m_pending_commands_map.find(request_id);
   if (it == m_pending_commands_map.end())
   {
     return false;
   }
+
   m_pending_commands_map.erase(it);
+
   return true;
 }
 

--- a/src/cola2/Command.cpp
+++ b/src/cola2/Command.cpp
@@ -32,9 +32,10 @@
  */
 //----------------------------------------------------------------------
 
-#include <sick_safetyscanners_base/cola2/Command.h>
+#include <sick_safetyscanners_base/logging/logging_wrapper.h>
 
 #include <sick_safetyscanners_base/cola2/Cola2Session.h>
+#include <sick_safetyscanners_base/cola2/Command.h>
 
 
 namespace sick {

--- a/src/cola2/Command.cpp
+++ b/src/cola2/Command.cpp
@@ -32,9 +32,10 @@
  */
 //----------------------------------------------------------------------
 
-#include <sick_safetyscanners_base/cola2/Command.h>
+#include <sick_safetyscanners_base/logging/logging_wrapper.h>
 
 #include <sick_safetyscanners_base/cola2/Cola2Session.h>
+#include <sick_safetyscanners_base/cola2/Command.h>
 
 
 namespace sick {
@@ -47,12 +48,6 @@ Command::Command(Cola2Session& session, const uint16_t& command_type, const uint
 {
   m_session_id     = m_session.getSessionID();
   m_request_id     = m_session.getNextRequestID();
-  m_tcp_parser_ptr = std::make_shared<sick::data_processing::ParseTCPPacket>();
-}
-
-void Command::lockExecutionMutex()
-{
-  m_execution_mutex.lock();
 }
 
 std::vector<uint8_t> Command::constructTelegram(const std::vector<uint8_t>& telegram) const
@@ -63,14 +58,8 @@ std::vector<uint8_t> Command::constructTelegram(const std::vector<uint8_t>& tele
 
 void Command::processReplyBase(const std::vector<uint8_t>& packet)
 {
-  m_tcp_parser_ptr->parseTCPSequence(packet, *this);
+  sick::data_processing::ParseTCPPacket::parseTCPSequence(packet, *this);
   m_was_successful = processReply();
-  m_execution_mutex.unlock();
-}
-
-void Command::waitForCompletion()
-{
-  boost::mutex::scoped_lock lock(m_execution_mutex);
 }
 
 bool Command::wasSuccessful() const

--- a/src/cola2/Command.cpp
+++ b/src/cola2/Command.cpp
@@ -50,11 +50,6 @@ Command::Command(Cola2Session& session, const uint16_t& command_type, const uint
   m_request_id     = m_session.getNextRequestID();
 }
 
-void Command::lockExecutionMutex()
-{
-  m_execution_mutex.lock();
-}
-
 std::vector<uint8_t> Command::constructTelegram(const std::vector<uint8_t>& telegram) const
 {
   auto v = addTelegramData(telegram);
@@ -65,12 +60,6 @@ void Command::processReplyBase(const std::vector<uint8_t>& packet)
 {
   sick::data_processing::ParseTCPPacket::parseTCPSequence(packet, *this);
   m_was_successful = processReply();
-  m_execution_mutex.unlock();
-}
-
-void Command::waitForCompletion()
-{
-  boost::mutex::scoped_lock lock(m_execution_mutex);
 }
 
 bool Command::wasSuccessful() const

--- a/src/cola2/Command.cpp
+++ b/src/cola2/Command.cpp
@@ -47,7 +47,6 @@ Command::Command(Cola2Session& session, const uint16_t& command_type, const uint
 {
   m_session_id     = m_session.getSessionID();
   m_request_id     = m_session.getNextRequestID();
-  m_tcp_parser_ptr = std::make_shared<sick::data_processing::ParseTCPPacket>();
 }
 
 void Command::lockExecutionMutex()
@@ -63,7 +62,7 @@ std::vector<uint8_t> Command::constructTelegram(const std::vector<uint8_t>& tele
 
 void Command::processReplyBase(const std::vector<uint8_t>& packet)
 {
-  m_tcp_parser_ptr->parseTCPSequence(packet, *this);
+  sick::data_processing::ParseTCPPacket::parseTCPSequence(packet, *this);
   m_was_successful = processReply();
   m_execution_mutex.unlock();
 }

--- a/src/cola2/ConfigMetadataVariableCommand.cpp
+++ b/src/cola2/ConfigMetadataVariableCommand.cpp
@@ -45,7 +45,6 @@ ConfigMetadataVariableCommand::ConfigMetadataVariableCommand(
   : VariableCommand(session, 28)
   , m_config_metadata(config_metadata)
 {
-  m_config_metadata_parser_ptr = std::make_shared<sick::data_processing::ParseConfigMetadata>();
 }
 
 bool ConfigMetadataVariableCommand::canBeExecutedWithoutSessionID() const
@@ -59,8 +58,8 @@ bool ConfigMetadataVariableCommand::processReply()
   {
     return false;
   }
-  m_config_metadata_parser_ptr->parseTCPSequence(getDataVector(), m_config_metadata);
-  return true;
+
+  return sick::data_processing::ParseConfigMetadata::parseTCPSequence(getDataVector(), m_config_metadata);
 }
 
 

--- a/src/cola2/CreateSession.cpp
+++ b/src/cola2/CreateSession.cpp
@@ -32,10 +32,12 @@
  */
 //----------------------------------------------------------------------
 
-#include <sick_safetyscanners_base/cola2/CreateSession.h>
+#include <sick_safetyscanners_base/logging/logging_wrapper.h>
 
 #include <sick_safetyscanners_base/cola2/Cola2Session.h>
 #include <sick_safetyscanners_base/cola2/Command.h>
+
+#include <sick_safetyscanners_base/cola2/CreateSession.h>
 
 namespace sick {
 namespace cola2 {

--- a/src/cola2/DeviceNameVariableCommand.cpp
+++ b/src/cola2/DeviceNameVariableCommand.cpp
@@ -45,7 +45,6 @@ DeviceNameVariableCommand::DeviceNameVariableCommand(Cola2Session& session,
   : VariableCommand(session, 17)
   , m_device_name(device_name)
 {
-  m_device_name_parser_ptr = std::make_shared<sick::data_processing::ParseDeviceName>();
 }
 
 bool DeviceNameVariableCommand::canBeExecutedWithoutSessionID() const
@@ -60,10 +59,7 @@ bool DeviceNameVariableCommand::processReply()
     return false;
   }
 
-  m_device_name_parser_ptr->parseTCPSequence(getDataVector(), m_device_name);
-
-
-  return true;
+  return sick::data_processing::ParseDeviceName::parseTCPSequence(getDataVector(), m_device_name);
 }
 
 

--- a/src/cola2/DeviceStatusVariableCommand.cpp
+++ b/src/cola2/DeviceStatusVariableCommand.cpp
@@ -45,7 +45,6 @@ DeviceStatusVariableCommand::DeviceStatusVariableCommand(
   : VariableCommand(session, 15)
   , m_device_status(device_status)
 {
-  m_device_status_parser_ptr = std::make_shared<sick::data_processing::ParseDeviceStatusData>();
 }
 
 bool DeviceStatusVariableCommand::canBeExecutedWithoutSessionID() const
@@ -59,8 +58,8 @@ bool DeviceStatusVariableCommand::processReply()
   {
     return false;
   }
-  m_device_status_parser_ptr->parseTCPSequence(getDataVector(), m_device_status);
-  return true;
+
+  return sick::data_processing::ParseDeviceStatusData::parseTCPSequence(getDataVector(), m_device_status);
 }
 
 

--- a/src/cola2/FieldGeometryVariableCommand.cpp
+++ b/src/cola2/FieldGeometryVariableCommand.cpp
@@ -46,7 +46,6 @@ FieldGeometryVariableCommand::FieldGeometryVariableCommand(Cola2Session& session
   : VariableCommand(session, 0x2810 + index)
   , m_field_data(field_data)
 {
-  m_field_geometry_parser_ptr = std::make_shared<sick::data_processing::ParseFieldGeometryData>();
 }
 
 bool FieldGeometryVariableCommand::canBeExecutedWithoutSessionID() const
@@ -60,8 +59,8 @@ bool FieldGeometryVariableCommand::processReply()
   {
     return false;
   }
-  m_field_geometry_parser_ptr->parseTCPSequence(getDataVector(), m_field_data);
-  return true;
+
+  return sick::data_processing::ParseFieldGeometryData::parseTCPSequence(getDataVector(), m_field_data);
 }
 
 

--- a/src/cola2/FieldHeaderVariableCommand.cpp
+++ b/src/cola2/FieldHeaderVariableCommand.cpp
@@ -46,7 +46,6 @@ FieldHeaderVariableCommand::FieldHeaderVariableCommand(Cola2Session& session,
   : VariableCommand(session, 0x2710 + index)
   , m_field_data(field_data)
 {
-  m_field_header_parser_ptr = std::make_shared<sick::data_processing::ParseFieldHeaderData>();
 }
 
 bool FieldHeaderVariableCommand::canBeExecutedWithoutSessionID() const
@@ -61,8 +60,7 @@ bool FieldHeaderVariableCommand::processReply()
     return false;
   }
 
-  m_field_header_parser_ptr->parseTCPSequence(getDataVector(), m_field_data);
-  return true;
+  return sick::data_processing::ParseFieldHeaderData::parseTCPSequence(getDataVector(), m_field_data);
 }
 
 

--- a/src/cola2/FieldSetsVariableCommand.cpp
+++ b/src/cola2/FieldSetsVariableCommand.cpp
@@ -45,7 +45,6 @@ FieldSetsVariableCommand::FieldSetsVariableCommand(Cola2Session& session,
   : VariableCommand(session, 1003)
   , m_field_sets(field_sets)
 {
-  m_field_sets_parser_ptr = std::make_shared<sick::data_processing::ParseFieldSetsData>();
 }
 
 bool FieldSetsVariableCommand::canBeExecutedWithoutSessionID() const
@@ -59,8 +58,8 @@ bool FieldSetsVariableCommand::processReply()
   {
     return false;
   }
-  m_field_sets_parser_ptr->parseTCPSequence(getDataVector(), m_field_sets);
-  return true;
+
+  return sick::data_processing::ParseFieldSetsData::parseTCPSequence(getDataVector(), m_field_sets);
 }
 
 

--- a/src/cola2/FirmwareVersionVariableCommand.cpp
+++ b/src/cola2/FirmwareVersionVariableCommand.cpp
@@ -45,7 +45,6 @@ FirmwareVersionVariableCommand::FirmwareVersionVariableCommand(
   : VariableCommand(session, 4)
   , m_firmware_version(firmware_version)
 {
-  m_firmware_version_parser_ptr = std::make_shared<sick::data_processing::ParseFirmwareVersion>();
 }
 
 bool FirmwareVersionVariableCommand::canBeExecutedWithoutSessionID() const
@@ -60,10 +59,7 @@ bool FirmwareVersionVariableCommand::processReply()
     return false;
   }
 
-  m_firmware_version_parser_ptr->parseTCPSequence(getDataVector(), m_firmware_version);
-
-
-  return true;
+  return sick::data_processing::ParseFirmwareVersion::parseTCPSequence(getDataVector(), m_firmware_version);
 }
 
 

--- a/src/cola2/LatestTelegramVariableCommand.cpp
+++ b/src/cola2/LatestTelegramVariableCommand.cpp
@@ -46,7 +46,6 @@ LatestTelegramVariableCommand::LatestTelegramVariableCommand(Cola2Session& sessi
   : VariableCommand(session, 179 + index)
   , m_data(data)
 {
-  m_data_parser_ptr = std::make_shared<sick::data_processing::ParseData>();
 }
 
 bool LatestTelegramVariableCommand::canBeExecutedWithoutSessionID() const
@@ -61,7 +60,7 @@ bool LatestTelegramVariableCommand::processReply()
     return false;
   }
 
-  m_data_parser_ptr->parseTCPSequence(getDataVector(), m_data);
+  sick::data_processing::ParseData::parseTCPSequence( getDataVector(), m_data );
 
 
   return true;

--- a/src/cola2/MeasurementCurrentConfigVariableCommand.cpp
+++ b/src/cola2/MeasurementCurrentConfigVariableCommand.cpp
@@ -45,8 +45,6 @@ MeasurementCurrentConfigVariableCommand::MeasurementCurrentConfigVariableCommand
   : VariableCommand(session, 178)
   , m_config_data(config_data)
 {
-  m_measurement_current_config_parser_ptr =
-    std::make_shared<sick::data_processing::ParseMeasurementCurrentConfigData>();
 }
 
 bool MeasurementCurrentConfigVariableCommand::canBeExecutedWithoutSessionID() const
@@ -60,8 +58,8 @@ bool MeasurementCurrentConfigVariableCommand::processReply()
   {
     return false;
   }
-  m_measurement_current_config_parser_ptr->parseTCPSequence(getDataVector(), m_config_data);
-  return true;
+
+  return sick::data_processing::ParseMeasurementCurrentConfigData::parseTCPSequence(getDataVector(), m_config_data);
 }
 
 

--- a/src/cola2/MeasurementPersistentConfigVariableCommand.cpp
+++ b/src/cola2/MeasurementPersistentConfigVariableCommand.cpp
@@ -45,8 +45,6 @@ MeasurementPersistentConfigVariableCommand::MeasurementPersistentConfigVariableC
   : VariableCommand(session, 177)
   , m_config_data(config_data)
 {
-  m_measurement_persistent_config_parser_ptr =
-    std::make_shared<sick::data_processing::ParseMeasurementPersistentConfigData>();
 }
 
 bool MeasurementPersistentConfigVariableCommand::canBeExecutedWithoutSessionID() const
@@ -60,8 +58,8 @@ bool MeasurementPersistentConfigVariableCommand::processReply()
   {
     return false;
   }
-  m_measurement_persistent_config_parser_ptr->parseTCPSequence(getDataVector(), m_config_data);
-  return true;
+
+  return sick::data_processing::ParseMeasurementPersistentConfigData::parseTCPSequence(getDataVector(), m_config_data);
 }
 
 

--- a/src/cola2/MethodCommand.cpp
+++ b/src/cola2/MethodCommand.cpp
@@ -32,10 +32,12 @@
  */
 //----------------------------------------------------------------------
 
-#include <sick_safetyscanners_base/cola2/MethodCommand.h>
+#include <sick_safetyscanners_base/logging/logging_wrapper.h>
 
 #include <sick_safetyscanners_base/cola2/Cola2Session.h>
 #include <sick_safetyscanners_base/cola2/Command.h>
+
+#include <sick_safetyscanners_base/cola2/MethodCommand.h>
 
 namespace sick {
 namespace cola2 {

--- a/src/cola2/MonitoringCaseTableHeaderVariableCommand.cpp
+++ b/src/cola2/MonitoringCaseTableHeaderVariableCommand.cpp
@@ -46,7 +46,6 @@ MonitoringCaseTableHeaderVariableCommand::MonitoringCaseTableHeaderVariableComma
   Cola2Session& session, datastructure::FieldData& field_data)
   : VariableCommand(session, 2100)
 {
-  m_field_header_parser_ptr = std::make_shared<sick::data_processing::ParseFieldHeaderData>();
 }
 
 bool MonitoringCaseTableHeaderVariableCommand::canBeExecutedWithoutSessionID() const

--- a/src/cola2/MonitoringCaseVariableCommand.cpp
+++ b/src/cola2/MonitoringCaseVariableCommand.cpp
@@ -48,7 +48,6 @@ MonitoringCaseVariableCommand::MonitoringCaseVariableCommand(
   : VariableCommand(session, 2101 + index)
   , m_monitoring_case_data(monitoring_case_data)
 {
-  m_monitoring_case_parser_ptr = std::make_shared<sick::data_processing::ParseMonitoringCaseData>();
 }
 
 bool MonitoringCaseVariableCommand::canBeExecutedWithoutSessionID() const
@@ -62,8 +61,8 @@ bool MonitoringCaseVariableCommand::processReply()
   {
     return false;
   }
-  m_monitoring_case_parser_ptr->parseTCPSequence(getDataVector(), m_monitoring_case_data);
-  return true;
+
+  return sick::data_processing::ParseMonitoringCaseData::parseTCPSequence(getDataVector(), m_monitoring_case_data);
 }
 
 

--- a/src/cola2/OrderNumberVariableCommand.cpp
+++ b/src/cola2/OrderNumberVariableCommand.cpp
@@ -45,7 +45,6 @@ OrderNumberVariableCommand::OrderNumberVariableCommand(Cola2Session& session,
   : VariableCommand(session, 14)
   , m_order_number(order_number)
 {
-  m_order_number_parser_ptr = std::make_shared<sick::data_processing::ParseOrderNumber>();
 }
 
 bool OrderNumberVariableCommand::canBeExecutedWithoutSessionID() const
@@ -60,10 +59,7 @@ bool OrderNumberVariableCommand::processReply()
     return false;
   }
 
-  m_order_number_parser_ptr->parseTCPSequence(getDataVector(), m_order_number);
-
-
-  return true;
+  return sick::data_processing::ParseOrderNumber::parseTCPSequence(getDataVector(), m_order_number);
 }
 
 

--- a/src/cola2/ProjectNameVariableCommand.cpp
+++ b/src/cola2/ProjectNameVariableCommand.cpp
@@ -45,7 +45,6 @@ ProjectNameVariableCommand::ProjectNameVariableCommand(Cola2Session& session,
   : VariableCommand(session, 18)
   , m_project_name(project_name)
 {
-  m_project_name_parser_ptr = std::make_shared<sick::data_processing::ParseProjectName>();
 }
 
 bool ProjectNameVariableCommand::canBeExecutedWithoutSessionID() const
@@ -60,10 +59,7 @@ bool ProjectNameVariableCommand::processReply()
     return false;
   }
 
-  m_project_name_parser_ptr->parseTCPSequence(getDataVector(), m_project_name);
-
-
-  return true;
+  return sick::data_processing::ParseProjectName::parseTCPSequence(getDataVector(), m_project_name);
 }
 
 

--- a/src/cola2/RequiredUserActionVariableCommand.cpp
+++ b/src/cola2/RequiredUserActionVariableCommand.cpp
@@ -45,8 +45,6 @@ RequiredUserActionVariableCommand::RequiredUserActionVariableCommand(
   : VariableCommand(session, 16)
   , m_required_user_action(required_user_action)
 {
-  m_required_user_action_parser_ptr =
-    std::make_shared<sick::data_processing::ParseRequiredUserActionData>();
 }
 
 bool RequiredUserActionVariableCommand::canBeExecutedWithoutSessionID() const
@@ -60,8 +58,8 @@ bool RequiredUserActionVariableCommand::processReply()
   {
     return false;
   }
-  m_required_user_action_parser_ptr->parseTCPSequence(getDataVector(), m_required_user_action);
-  return true;
+
+  return sick::data_processing::ParseRequiredUserActionData::parseTCPSequence(getDataVector(), m_required_user_action);
 }
 
 

--- a/src/cola2/SerialNumberVariableCommand.cpp
+++ b/src/cola2/SerialNumberVariableCommand.cpp
@@ -45,7 +45,6 @@ SerialNumberVariableCommand::SerialNumberVariableCommand(Cola2Session& session,
   : VariableCommand(session, 3)
   , m_serial_number(serial_number)
 {
-  m_serial_number_parser_ptr = std::make_shared<sick::data_processing::ParseSerialNumber>();
 }
 
 bool SerialNumberVariableCommand::canBeExecutedWithoutSessionID() const
@@ -60,10 +59,7 @@ bool SerialNumberVariableCommand::processReply()
     return false;
   }
 
-  m_serial_number_parser_ptr->parseTCPSequence(getDataVector(), m_serial_number);
-
-
-  return true;
+  return sick::data_processing::ParseSerialNumber::parseTCPSequence(getDataVector(), m_serial_number);
 }
 
 

--- a/src/cola2/StatusOverviewVariableCommand.cpp
+++ b/src/cola2/StatusOverviewVariableCommand.cpp
@@ -45,7 +45,6 @@ StatusOverviewVariableCommand::StatusOverviewVariableCommand(
   : VariableCommand(session, 23)
   , m_status_overview(status_overview)
 {
-  m_status_overview_parser_ptr = std::make_shared<sick::data_processing::ParseStatusOverviewData>();
 }
 
 bool StatusOverviewVariableCommand::canBeExecutedWithoutSessionID() const
@@ -59,8 +58,8 @@ bool StatusOverviewVariableCommand::processReply()
   {
     return false;
   }
-  m_status_overview_parser_ptr->parseTCPSequence(getDataVector(), m_status_overview);
-  return true;
+
+  return sick::data_processing::ParseStatusOverviewData::parseTCPSequence(getDataVector(), m_status_overview);
 }
 
 

--- a/src/cola2/TypeCodeVariableCommand.cpp
+++ b/src/cola2/TypeCodeVariableCommand.cpp
@@ -45,7 +45,6 @@ TypeCodeVariableCommand::TypeCodeVariableCommand(Cola2Session& session,
   : VariableCommand(session, 0x000d)
   , m_type_code(type_code)
 {
-  m_type_code_parser_ptr = std::make_shared<sick::data_processing::ParseTypeCodeData>();
 }
 
 bool TypeCodeVariableCommand::canBeExecutedWithoutSessionID() const
@@ -59,8 +58,8 @@ bool TypeCodeVariableCommand::processReply()
   {
     return false;
   }
-  m_type_code_parser_ptr->parseTCPSequence(getDataVector(), m_type_code);
-  return true;
+
+  return sick::data_processing::ParseTypeCodeData::parseTCPSequence(getDataVector(), m_type_code);
 }
 
 

--- a/src/cola2/UserNameVariableCommand.cpp
+++ b/src/cola2/UserNameVariableCommand.cpp
@@ -45,7 +45,6 @@ UserNameVariableCommand::UserNameVariableCommand(Cola2Session& session,
   : VariableCommand(session, 35)
   , m_user_name(user_name)
 {
-  m_user_name_parser_ptr = std::make_shared<sick::data_processing::ParseUserNameData>();
 }
 
 bool UserNameVariableCommand::canBeExecutedWithoutSessionID() const
@@ -59,8 +58,8 @@ bool UserNameVariableCommand::processReply()
   {
     return false;
   }
-  m_user_name_parser_ptr->parseTCPSequence(getDataVector(), m_user_name);
-  return true;
+
+  return sick::data_processing::ParseUserNameData::parseTCPSequence(getDataVector(), m_user_name);
 }
 
 

--- a/src/cola2/VariableCommand.cpp
+++ b/src/cola2/VariableCommand.cpp
@@ -32,10 +32,12 @@
  */
 //----------------------------------------------------------------------
 
-#include <sick_safetyscanners_base/cola2/VariableCommand.h>
+#include <sick_safetyscanners_base/logging/logging_wrapper.h>
 
 #include <sick_safetyscanners_base/cola2/Cola2Session.h>
 #include <sick_safetyscanners_base/cola2/Command.h>
+
+#include <sick_safetyscanners_base/cola2/VariableCommand.h>
 
 namespace sick {
 namespace cola2 {

--- a/src/communication/AsyncTCPClient.cpp
+++ b/src/communication/AsyncTCPClient.cpp
@@ -38,16 +38,11 @@
 
 namespace sick {
 namespace communication {
-AsyncTCPClient::AsyncTCPClient(const PacketHandler& packet_handler,
-                               boost::asio::io_service& io_service,
+AsyncTCPClient::AsyncTCPClient(boost::asio::io_service& io_service,
                                const boost::asio::ip::address_v4& server_ip,
                                const uint16_t& server_port)
-  : m_packet_handler(packet_handler)
-  , m_io_service(io_service)
-
+  : m_io_service(io_service)
 {
-  // Keep io_service busy
-  m_io_work_ptr = std::make_shared<boost::asio::io_service::work>(boost::ref(m_io_service));
   try
   {
     m_socket_ptr = std::make_shared<boost::asio::ip::tcp::socket>(boost::ref(m_io_service));
@@ -56,18 +51,24 @@ AsyncTCPClient::AsyncTCPClient(const PacketHandler& packet_handler,
   {
     ROS_ERROR("Exception while creating socket: %s", e.what());
   }
+
   m_remote_endpoint = boost::asio::ip::tcp::endpoint(server_ip, server_port);
   ROS_INFO("TCP client is setup");
 }
 
 AsyncTCPClient::~AsyncTCPClient() {}
 
-void AsyncTCPClient::doDisconnect()
+void AsyncTCPClient::doConnect( CompleteHandler handler )
+{
+  m_socket_ptr->async_connect(m_remote_endpoint, handler );
+}
+
+boost::system::error_code AsyncTCPClient::doDisconnect()
 {
   boost::mutex::scoped_lock lock(m_socket_mutex);
   boost::system::error_code ec;
   m_socket_ptr->shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
-  if (ec != 0)
+  if (ec)
   {
     ROS_ERROR("Error shutting socket down: %i", ec.value());
   }
@@ -77,7 +78,7 @@ void AsyncTCPClient::doDisconnect()
   }
 
   m_socket_ptr->close(ec);
-  if (ec != 0)
+  if (ec)
   {
     ROS_ERROR("Error closing Socket: %i", ec.value());
   }
@@ -85,88 +86,52 @@ void AsyncTCPClient::doDisconnect()
   {
     ROS_INFO("TCP Socket successfully closed.");
   }
+
+  return ec;
 }
 
-void AsyncTCPClient::doConnect()
+void AsyncTCPClient::send(const std::vector<uint8_t>& sendBuffer, CompleteHandler handler)
 {
-  boost::mutex::scoped_lock lock(m_socket_mutex);
-  boost::mutex::scoped_lock lock_connect(m_connect_mutex);
-  m_socket_ptr->async_connect(m_remote_endpoint, [this](boost::system::error_code ec) {
-    if (ec != 0)
-    {
-      ROS_ERROR("TCP error code: %i", ec.value());
-    }
-    else
-    {
-      ROS_INFO("TCP connection successfully established.");
-    }
-    m_connect_condition.notify_all();
-  });
-
-  m_connect_condition.wait(lock_connect);
-}
-
-
-void AsyncTCPClient::doSendAndReceive(const std::vector<uint8_t>& sendBuffer)
-{
-  boost::mutex::scoped_lock lock(m_socket_mutex);
   if (!m_socket_ptr)
   {
+    handler( boost::asio::error::not_connected );
     return;
   }
+
   boost::asio::async_write(*m_socket_ptr,
                            boost::asio::buffer(sendBuffer),
-                           [this](boost::system::error_code ec, std::size_t bytes_send) {
-                             this->handleSendAndReceive(ec, bytes_send);
-                           });
+                           std::bind( handler, std::placeholders::_1 ) );
 }
 
-void AsyncTCPClient::initiateReceive()
+void AsyncTCPClient::readSome( PacketHandler handler )
 {
-  boost::mutex::scoped_lock lock(m_socket_mutex);
   if (!m_socket_ptr)
   {
+    handler( sick::datastructure::PacketBuffer(), boost::asio::error::not_connected );
     return;
   }
+
   m_socket_ptr->async_read_some(boost::asio::buffer(m_recv_buffer),
-                                [this](boost::system::error_code ec, std::size_t bytes_recvd) {
-                                  this->handleReceive(ec, bytes_recvd);
-                                });
+                                std::bind( &AsyncTCPClient::handleReceive,
+                                           this,
+                                           handler,
+                                           std::placeholders::_1, std::placeholders::_2 ) );
 }
 
-void AsyncTCPClient::setPacketHandler(const PacketHandler& packet_handler)
-{
-  m_packet_handler = packet_handler;
-}
-
-void AsyncTCPClient::handleSendAndReceive(const boost::system::error_code& error,
-                                          const std::size_t& bytes_transferred)
-{
-  // Check for errors
-  if (!error || error == boost::asio::error::message_size)
-  {
-    initiateReceive();
-  }
-  else
-  {
-    ROS_ERROR("Error in tcp handle send and receive: %i", error.value());
-  }
-}
-
-
-void AsyncTCPClient::startReceive() {}
-
-void AsyncTCPClient::handleReceive(const boost::system::error_code& error,
+void AsyncTCPClient::handleReceive(PacketHandler handler,
+                                   const boost::system::error_code& error,
                                    const std::size_t& bytes_transferred)
 {
   if (!error)
   {
     sick::datastructure::PacketBuffer packet_buffer(m_recv_buffer, bytes_transferred);
-    m_packet_handler(packet_buffer);
+    handler( packet_buffer, error );
   }
   else
   {
     ROS_ERROR("Error in tcp handle receive: %i", error.value());
+
+    handler( sick::datastructure::PacketBuffer(), error );
   }
 }
 

--- a/src/communication/AsyncTCPClient.cpp
+++ b/src/communication/AsyncTCPClient.cpp
@@ -32,6 +32,8 @@
  */
 //----------------------------------------------------------------------
 
+#include <sick_safetyscanners_base/logging/logging_wrapper.h>
+
 #include <sick_safetyscanners_base/communication/AsyncTCPClient.h>
 
 namespace sick {

--- a/src/communication/AsyncUDPClient.cpp
+++ b/src/communication/AsyncUDPClient.cpp
@@ -32,6 +32,7 @@
  */
 //----------------------------------------------------------------------
 
+#include <sick_safetyscanners_base/logging/logging_wrapper.h>
 
 #include <sick_safetyscanners_base/communication/AsyncUDPClient.h>
 

--- a/src/communication/AsyncUDPClient.cpp
+++ b/src/communication/AsyncUDPClient.cpp
@@ -32,74 +32,83 @@
  */
 //----------------------------------------------------------------------
 
+#include <sick_safetyscanners_base/logging/logging_wrapper.h>
 
 #include <sick_safetyscanners_base/communication/AsyncUDPClient.h>
 
 namespace sick {
 namespace communication {
 AsyncUDPClient::AsyncUDPClient(const PacketHandler& packet_handler,
-                               boost::asio::io_service& io_service,
-                               const uint16_t& local_port)
+                               boost::asio::io_service& io_service)
   : m_packet_handler(packet_handler)
   , m_io_service(io_service)
 {
-  // Keep io_service busy
-  m_io_work_ptr = std::make_shared<boost::asio::io_service::work>(boost::ref(m_io_service));
   try
   {
-    m_socket_ptr = std::make_shared<boost::asio::ip::udp::socket>(
-      boost::ref(m_io_service),
-      boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), local_port));
+    m_socket_ptr = std::make_shared<boost::asio::ip::udp::socket>(m_io_service);
   }
   catch (std::exception& e)
   {
     ROS_ERROR("Exception while creating socket: %s", e.what());
   }
+
   ROS_INFO("UDP client is setup");
 }
 
 AsyncUDPClient::~AsyncUDPClient()
 {
-  m_io_service.stop();
+}
+
+boost::system::error_code AsyncUDPClient::open(const uint16_t& local_port)
+{
+  boost::system::error_code ec;
+
+  boost::asio::ip::udp::endpoint endpoint(boost::asio::ip::udp::v4(), local_port);
+  m_socket_ptr->open( endpoint.protocol(), ec );
+  m_socket_ptr->bind( endpoint, ec );
+
+  return ec;
+}
+
+void AsyncUDPClient::start()
+{
+  startReceive();
+}
+
+void AsyncUDPClient::stop()
+{
+  boost::system::error_code ec;
+  m_socket_ptr->shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+
+  m_socket_ptr->close(ec);
+}
+
+AsyncUDPClient::endpoint_type AsyncUDPClient::getLocalEndpoint() const
+{
+  return m_socket_ptr->local_endpoint();
 }
 
 void AsyncUDPClient::startReceive()
 {
   m_socket_ptr->async_receive_from(boost::asio::buffer(m_recv_buffer),
                                    m_remote_endpoint,
-                                   [this](boost::system::error_code ec, std::size_t bytes_recvd) {
-                                     this->handleReceive(ec, bytes_recvd);
-                                   });
+                                   std::bind( &AsyncUDPClient::handleReceive, this, std::placeholders::_1, std::placeholders::_2 ) );
 }
 
 void AsyncUDPClient::handleReceive(const boost::system::error_code& error,
                                    const std::size_t& bytes_transferred)
 {
-  if (!error)
+  if ( !error )
   {
     sick::datastructure::PacketBuffer packet_buffer(m_recv_buffer, bytes_transferred);
     m_packet_handler(packet_buffer);
+
+    startReceive();
   }
   else
   {
     ROS_ERROR("Error in UDP handle receive: %i", error.value());
   }
-  startReceive();
-}
-
-
-void AsyncUDPClient::runService()
-{
-  startReceive();
-}
-
-unsigned short AsyncUDPClient::getLocalPort()
-{
-  if (m_socket_ptr)
-  {
-    return m_socket_ptr->local_endpoint().port();
-  }
-  return 0;
 }
 
 } // namespace communication

--- a/src/data_processing/ParseApplicationData.cpp
+++ b/src/data_processing/ParseApplicationData.cpp
@@ -41,7 +41,7 @@ ParseApplicationData::ParseApplicationData() {}
 
 datastructure::ApplicationData
 ParseApplicationData::parseUDPSequence(const datastructure::PacketBuffer& buffer,
-                                       datastructure::Data& data) const
+                                       datastructure::Data& data)
 {
   datastructure::ApplicationData application_data;
 
@@ -59,7 +59,7 @@ ParseApplicationData::parseUDPSequence(const datastructure::PacketBuffer& buffer
   return application_data;
 }
 
-bool ParseApplicationData::checkIfPreconditionsAreMet(const datastructure::Data& data) const
+bool ParseApplicationData::checkIfPreconditionsAreMet(const datastructure::Data& data)
 {
   if (!checkIfApplicationDataIsPublished(data))
   {
@@ -72,21 +72,21 @@ bool ParseApplicationData::checkIfPreconditionsAreMet(const datastructure::Data&
   return true;
 }
 
-bool ParseApplicationData::checkIfApplicationDataIsPublished(const datastructure::Data& data) const
+bool ParseApplicationData::checkIfApplicationDataIsPublished(const datastructure::Data& data)
 {
   return !(data.getDataHeaderPtr()->getApplicationDataBlockOffset() == 0 &&
            data.getDataHeaderPtr()->getApplicationDataBlockSize() == 0);
 }
 
 bool ParseApplicationData::checkIfDataContainsNeededParsedBlocks(
-  const datastructure::Data& data) const
+  const datastructure::Data& data)
 {
   return !(data.getDataHeaderPtr()->isEmpty());
 }
 
 void ParseApplicationData::setDataInApplicationData(
   std::vector<uint8_t>::const_iterator data_ptr,
-  datastructure::ApplicationData& application_data) const
+  datastructure::ApplicationData& application_data)
 {
   setApplicationInputsInApplicationData(data_ptr, application_data);
   setApplicationOutputsInApplicationData(data_ptr, application_data);
@@ -94,7 +94,7 @@ void ParseApplicationData::setDataInApplicationData(
 
 void ParseApplicationData::setApplicationInputsInApplicationData(
   std::vector<uint8_t>::const_iterator data_ptr,
-  datastructure::ApplicationData& application_data) const
+  datastructure::ApplicationData& application_data)
 {
   datastructure::ApplicationInputs inputs;
   setDataInApplicationInputs(data_ptr, inputs);
@@ -103,7 +103,7 @@ void ParseApplicationData::setApplicationInputsInApplicationData(
 
 void ParseApplicationData::setApplicationOutputsInApplicationData(
   std::vector<uint8_t>::const_iterator data_ptr,
-  datastructure::ApplicationData& application_data) const
+  datastructure::ApplicationData& application_data)
 {
   datastructure::ApplicationOutputs outputs;
   setDataInApplicationOutputs(data_ptr, outputs);
@@ -111,7 +111,7 @@ void ParseApplicationData::setApplicationOutputsInApplicationData(
 }
 
 void ParseApplicationData::setDataInApplicationInputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs)
 {
   setUnsafeInputsInApplicationInputs(data_ptr, inputs);
   setMonitoringCaseInputsInApplicationInputs(data_ptr, inputs);
@@ -120,7 +120,7 @@ void ParseApplicationData::setDataInApplicationInputs(
 }
 
 void ParseApplicationData::setDataInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   setEvalutaionPathsOutputsInApplicationOutputs(data_ptr, outputs);
   setMonitoringCaseOutputsInApplicationOutputs(data_ptr, outputs);
@@ -132,14 +132,14 @@ void ParseApplicationData::setDataInApplicationOutputs(
 }
 
 void ParseApplicationData::setUnsafeInputsInApplicationInputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs)
 {
   setUnsafeInputsSourcesInApplicationInputs(data_ptr, inputs);
   setUnsafeInputsFlagsInApplicationInputs(data_ptr, inputs);
 }
 
 void ParseApplicationData::setUnsafeInputsSourcesInApplicationInputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs)
 {
   uint32_t word32 = read_write_helper::readUint32LittleEndian(data_ptr + 0);
   std::vector<bool> input_sources;
@@ -151,7 +151,7 @@ void ParseApplicationData::setUnsafeInputsSourcesInApplicationInputs(
 }
 
 void ParseApplicationData::setUnsafeInputsFlagsInApplicationInputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs)
 {
   uint32_t word32 = read_write_helper::readUint32LittleEndian(data_ptr + 4);
   std::vector<bool> input_flags;
@@ -163,14 +163,14 @@ void ParseApplicationData::setUnsafeInputsFlagsInApplicationInputs(
 }
 
 void ParseApplicationData::setMonitoringCaseInputsInApplicationInputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs)
 {
   setMonitoringCaseNumbersInApplicationInputs(data_ptr, inputs);
   setMonitoringCaseFlagsInApplicationInputs(data_ptr, inputs);
 }
 
 void ParseApplicationData::setMonitoringCaseNumbersInApplicationInputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs)
 {
   std::vector<uint16_t> monitoring_cases;
   for (uint8_t i = 0; i < 20; i++)
@@ -182,7 +182,7 @@ void ParseApplicationData::setMonitoringCaseNumbersInApplicationInputs(
 
 
 void ParseApplicationData::setMonitoringCaseFlagsInApplicationInputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs)
 {
   uint32_t word32 = read_write_helper::readUint32LittleEndian(data_ptr + 52);
   std::vector<bool> monitoring_flags;
@@ -195,7 +195,7 @@ void ParseApplicationData::setMonitoringCaseFlagsInApplicationInputs(
 }
 
 void ParseApplicationData::setLinearVelocityInputsInApplicationInputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs)
 {
   setLinearVelocity0InApplicationInputs(data_ptr, inputs);
   setLinearVelocity1InApplicationInputs(data_ptr, inputs);
@@ -203,19 +203,19 @@ void ParseApplicationData::setLinearVelocityInputsInApplicationInputs(
 }
 
 void ParseApplicationData::setLinearVelocity0InApplicationInputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs)
 {
   inputs.setVelocity0(read_write_helper::readUint16LittleEndian(data_ptr + 56));
 }
 
 void ParseApplicationData::setLinearVelocity1InApplicationInputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs)
 {
   inputs.setVelocity1(read_write_helper::readUint16LittleEndian(data_ptr + 58));
 }
 
 void ParseApplicationData::setLinearVelocityFlagsInApplicationInputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs)
 {
   uint8_t word8 = read_write_helper::readUint8LittleEndian(data_ptr + 60);
 
@@ -227,14 +227,14 @@ void ParseApplicationData::setLinearVelocityFlagsInApplicationInputs(
 }
 
 void ParseApplicationData::setSleepModeInputInApplicationInputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationInputs& inputs)
 {
   inputs.setSleepModeInput(read_write_helper::readUint8LittleEndian(data_ptr + 74));
 }
 
 
 void ParseApplicationData::setEvalutaionPathsOutputsInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   setEvaluationPathsOutputsEvalOutInApplicationOutputs(data_ptr, outputs);
   setEvaluationPathsOutputsIsSafeInApplicationOutputs(data_ptr, outputs);
@@ -242,7 +242,7 @@ void ParseApplicationData::setEvalutaionPathsOutputsInApplicationOutputs(
 }
 
 void ParseApplicationData::setEvaluationPathsOutputsEvalOutInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   uint32_t word32 = read_write_helper::readUint32LittleEndian(data_ptr + 140);
 
@@ -255,7 +255,7 @@ void ParseApplicationData::setEvaluationPathsOutputsEvalOutInApplicationOutputs(
 }
 
 void ParseApplicationData::setEvaluationPathsOutputsIsSafeInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   uint32_t word32 = read_write_helper::readUint32LittleEndian(data_ptr + 144);
 
@@ -269,7 +269,7 @@ void ParseApplicationData::setEvaluationPathsOutputsIsSafeInApplicationOutputs(
 
 
 void ParseApplicationData::setEvaluationPathsOutputsValidFlagsInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   uint32_t word32 = read_write_helper::readUint32LittleEndian(data_ptr + 148);
 
@@ -282,14 +282,14 @@ void ParseApplicationData::setEvaluationPathsOutputsValidFlagsInApplicationOutpu
 }
 
 void ParseApplicationData::setMonitoringCaseOutputsInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   setMonitoringCaseNumbersInApplicationOutputs(data_ptr, outputs);
   setMonitoringCaseFlagsInApplicationOutputs(data_ptr, outputs);
 }
 
 void ParseApplicationData::setMonitoringCaseNumbersInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   std::vector<uint16_t> output_monitoring_cases;
 
@@ -303,7 +303,7 @@ void ParseApplicationData::setMonitoringCaseNumbersInApplicationOutputs(
 
 
 void ParseApplicationData::setMonitoringCaseFlagsInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   uint32_t word32 = read_write_helper::readUint32LittleEndian(data_ptr + 192);
 
@@ -317,13 +317,13 @@ void ParseApplicationData::setMonitoringCaseFlagsInApplicationOutputs(
 }
 
 void ParseApplicationData::setSleepModeOutputInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   outputs.setSleepModeOutput(read_write_helper::readUint8LittleEndian(data_ptr + 193));
 }
 
 void ParseApplicationData::setErrorFlagsInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   uint8_t word8 = read_write_helper::readUint8LittleEndian(data_ptr + 194);
 
@@ -336,7 +336,7 @@ void ParseApplicationData::setErrorFlagsInApplicationOutputs(
 }
 
 void ParseApplicationData::setLinearVelocityOutoutsInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   setLinearVelocity0InApplicationOutputs(data_ptr, outputs);
   setLinearVelocity1InApplicationOutputs(data_ptr, outputs);
@@ -344,19 +344,19 @@ void ParseApplicationData::setLinearVelocityOutoutsInApplicationOutputs(
 }
 
 void ParseApplicationData::setLinearVelocity0InApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   outputs.setVelocity0(read_write_helper::readUint16LittleEndian(data_ptr + 200));
 }
 
 void ParseApplicationData::setLinearVelocity1InApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   outputs.setVelocity1(read_write_helper::readUint16LittleEndian(data_ptr + 202));
 }
 
 void ParseApplicationData::setLinearVelocityFlagsInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   uint8_t word8 = read_write_helper::readUint8LittleEndian(data_ptr + 204);
 
@@ -369,14 +369,14 @@ void ParseApplicationData::setLinearVelocityFlagsInApplicationOutputs(
 }
 
 void ParseApplicationData::setResultingVelocityOutputsInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   setResultingVelocityInApplicationOutputs(data_ptr, outputs);
   setResultingVelocityFlagsInApplicationOutputs(data_ptr, outputs);
 }
 
 void ParseApplicationData::setResultingVelocityInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   std::vector<int16_t> resulting_velocities;
   for (uint8_t i = 0; i < 20; i++)
@@ -388,7 +388,7 @@ void ParseApplicationData::setResultingVelocityInApplicationOutputs(
 }
 
 void ParseApplicationData::setResultingVelocityFlagsInApplicationOutputs(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   uint32_t word32 = read_write_helper::readUint32LittleEndian(data_ptr + 248);
 
@@ -402,7 +402,7 @@ void ParseApplicationData::setResultingVelocityFlagsInApplicationOutputs(
 }
 
 void ParseApplicationData::setOutputFlagsinApplicationOutput(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::ApplicationOutputs& outputs)
 {
   uint8_t word8 = read_write_helper::readUint8LittleEndian(data_ptr + 259);
 

--- a/src/data_processing/ParseApplicationNameData.cpp
+++ b/src/data_processing/ParseApplicationNameData.cpp
@@ -44,7 +44,7 @@ ParseApplicationNameData::ParseApplicationNameData() {}
 
 bool ParseApplicationNameData::parseTCPSequence(
   const datastructure::PacketBuffer& buffer,
-  sick::datastructure::ApplicationName& application_name) const
+  sick::datastructure::ApplicationName& application_name)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -59,7 +59,7 @@ bool ParseApplicationNameData::parseTCPSequence(
 }
 
 std::string
-ParseApplicationNameData::readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseApplicationNameData::readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr)
 {
   std::string result;
   result.push_back(read_write_helper::readUint8(data_ptr + 0));
@@ -67,32 +67,32 @@ ParseApplicationNameData::readVersionIndicator(std::vector<uint8_t>::const_itera
 }
 
 uint8_t
-ParseApplicationNameData::readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseApplicationNameData::readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 1);
 }
 
 uint8_t
-ParseApplicationNameData::readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseApplicationNameData::readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 2);
 }
 
 uint8_t
-ParseApplicationNameData::readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseApplicationNameData::readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 3);
 }
 
 uint32_t
-ParseApplicationNameData::readNameLength(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseApplicationNameData::readNameLength(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 4);
 }
 
 
 std::string
-ParseApplicationNameData::readApplicationName(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseApplicationNameData::readApplicationName(std::vector<uint8_t>::const_iterator data_ptr)
 {
   uint32_t name_length = read_write_helper::readUint32LittleEndian(data_ptr + 4);
   std::string name;

--- a/src/data_processing/ParseConfigMetadata.cpp
+++ b/src/data_processing/ParseConfigMetadata.cpp
@@ -44,7 +44,7 @@ ParseConfigMetadata::ParseConfigMetadata() {}
 
 bool ParseConfigMetadata::parseTCPSequence(
   const datastructure::PacketBuffer& buffer,
-  sick::datastructure::ConfigMetadata& config_metadata) const
+  sick::datastructure::ConfigMetadata& config_metadata)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -64,65 +64,65 @@ bool ParseConfigMetadata::parseTCPSequence(
 }
 
 std::string
-ParseConfigMetadata::readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseConfigMetadata::readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr)
 {
   std::string result;
   result.push_back(read_write_helper::readUint8(data_ptr + 0));
   return result;
 }
 
-uint8_t ParseConfigMetadata::readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseConfigMetadata::readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 1);
 }
 
-uint8_t ParseConfigMetadata::readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseConfigMetadata::readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 2);
 }
 
-uint8_t ParseConfigMetadata::readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseConfigMetadata::readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 3);
 }
 
 uint16_t
-ParseConfigMetadata::readModificationTimeDate(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseConfigMetadata::readModificationTimeDate(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 4);
 }
 
 uint32_t
-ParseConfigMetadata::readModificationTimeTime(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseConfigMetadata::readModificationTimeTime(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 8);
 }
 
 uint16_t
-ParseConfigMetadata::readTransferTimeDate(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseConfigMetadata::readTransferTimeDate(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 12);
 }
 
 uint32_t
-ParseConfigMetadata::readTransferTimeTime(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseConfigMetadata::readTransferTimeTime(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 16);
 }
 
-uint32_t ParseConfigMetadata::readAppChecksum(std::vector<uint8_t>::const_iterator data_ptr) const
+uint32_t ParseConfigMetadata::readAppChecksum(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 36);
 }
 
 uint32_t
-ParseConfigMetadata::readOverallChecksum(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseConfigMetadata::readOverallChecksum(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 52);
 }
 
 std::vector<uint32_t>
-ParseConfigMetadata::readIntegrityHash(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseConfigMetadata::readIntegrityHash(std::vector<uint8_t>::const_iterator data_ptr)
 {
   std::vector<uint32_t> result;
   for (uint8_t i = 0; i < 4; i++)

--- a/src/data_processing/ParseData.cpp
+++ b/src/data_processing/ParseData.cpp
@@ -39,17 +39,10 @@ namespace data_processing {
 
 ParseData::ParseData()
 {
-  m_data_header_parser_ptr      = std::make_shared<sick::data_processing::ParseDataHeader>();
-  m_derived_values_parser_ptr   = std::make_shared<sick::data_processing::ParseDerivedValues>();
-  m_measurement_data_parser_ptr = std::make_shared<sick::data_processing::ParseMeasurementData>();
-  m_general_system_state_parser_ptr =
-    std::make_shared<sick::data_processing::ParseGeneralSystemState>();
-  m_intrusion_data_parser_ptr   = std::make_shared<sick::data_processing::ParseIntrusionData>();
-  m_application_data_parser_ptr = std::make_shared<sick::data_processing::ParseApplicationData>();
 }
 
 sick::datastructure::Data
-ParseData::parseUDPSequence(const datastructure::PacketBuffer& buffer) const
+ParseData::parseUDPSequence(const datastructure::PacketBuffer& buffer)
 {
   sick::datastructure::Data data;
   setDataBlocksInData(buffer, data);
@@ -57,7 +50,7 @@ ParseData::parseUDPSequence(const datastructure::PacketBuffer& buffer) const
 }
 
 void ParseData::setDataBlocksInData(const datastructure::PacketBuffer& buffer,
-                                    datastructure::Data& data) const
+                                    datastructure::Data& data)
 {
   setDataHeaderInData(buffer, data);
   setDerivedValuesInData(buffer, data);
@@ -68,52 +61,53 @@ void ParseData::setDataBlocksInData(const datastructure::PacketBuffer& buffer,
 }
 
 void ParseData::setDataHeaderInData(const datastructure::PacketBuffer& buffer,
-                                    datastructure::Data& data) const
+                                    datastructure::Data& data)
 {
   sick::datastructure::DataHeader data_header =
-    m_data_header_parser_ptr->parseUDPSequence(buffer, data);
+    sick::data_processing::ParseDataHeader::parseUDPSequence(buffer, data);
   data.setDataHeaderPtr(std::make_shared<sick::datastructure::DataHeader>(data_header));
 }
 
 void ParseData::setDerivedValuesInData(const datastructure::PacketBuffer& buffer,
-                                       datastructure::Data& data) const
+                                       datastructure::Data& data)
 {
   sick::datastructure::DerivedValues derived_values =
-    m_derived_values_parser_ptr->parseUDPSequence(buffer, data);
+    sick::data_processing::ParseDerivedValues::parseUDPSequence(buffer, data);
   data.setDerivedValuesPtr(std::make_shared<sick::datastructure::DerivedValues>(derived_values));
 }
 
 void ParseData::setMeasurementDataInData(const datastructure::PacketBuffer& buffer,
-                                         datastructure::Data& data) const
+                                         datastructure::Data& data)
 {
   sick::datastructure::MeasurementData measurement_data =
-    m_measurement_data_parser_ptr->parseUDPSequence(buffer, data);
+    sick::data_processing::ParseMeasurementData::parseUDPSequence(buffer, data);
   data.setMeasurementDataPtr(
     std::make_shared<sick::datastructure::MeasurementData>(measurement_data));
 }
 
 void ParseData::setGeneralSystemStateInData(const datastructure::PacketBuffer& buffer,
-                                            datastructure::Data& data) const
+                                            datastructure::Data& data)
 {
   sick::datastructure::GeneralSystemState general_system_state =
-    m_general_system_state_parser_ptr->parseUDPSequence(buffer, data);
+    sick::data_processing::ParseGeneralSystemState::parseUDPSequence(buffer, data);
   data.setGeneralSystemStatePtr(
     std::make_shared<sick::datastructure::GeneralSystemState>(general_system_state));
 }
 
 void ParseData::setIntrusionDataInData(const datastructure::PacketBuffer& buffer,
-                                       datastructure::Data& data) const
+                                       datastructure::Data& data)
 {
   sick::datastructure::IntrusionData intrusion_data =
-    m_intrusion_data_parser_ptr->parseUDPSequence(buffer, data);
+    sick::data_processing::ParseIntrusionData::parseUDPSequence(buffer, data);
   data.setIntrusionDataPtr(std::make_shared<sick::datastructure::IntrusionData>(intrusion_data));
 }
 
 void ParseData::setApplicationDataInData(const datastructure::PacketBuffer& buffer,
-                                         datastructure::Data& data) const
+                                         datastructure::Data& data)
 {
   sick::datastructure::ApplicationData application_data =
-    m_application_data_parser_ptr->parseUDPSequence(buffer, data);
+    sick::data_processing::ParseApplicationData::parseUDPSequence(buffer, data);
+
   data.setApplicationDataPtr(
     std::make_shared<sick::datastructure::ApplicationData>(application_data));
 }

--- a/src/data_processing/ParseData.cpp
+++ b/src/data_processing/ParseData.cpp
@@ -39,17 +39,10 @@ namespace data_processing {
 
 ParseData::ParseData()
 {
-  m_data_header_parser_ptr      = std::make_shared<sick::data_processing::ParseDataHeader>();
-  m_derived_values_parser_ptr   = std::make_shared<sick::data_processing::ParseDerivedValues>();
-  m_measurement_data_parser_ptr = std::make_shared<sick::data_processing::ParseMeasurementData>();
-  m_general_system_state_parser_ptr =
-    std::make_shared<sick::data_processing::ParseGeneralSystemState>();
-  m_intrusion_data_parser_ptr   = std::make_shared<sick::data_processing::ParseIntrusionData>();
-  m_application_data_parser_ptr = std::make_shared<sick::data_processing::ParseApplicationData>();
 }
 
 sick::datastructure::Data
-ParseData::parseUDPSequence(const datastructure::PacketBuffer& buffer) const
+ParseData::parseUDPSequence(const datastructure::PacketBuffer& buffer)
 {
   sick::datastructure::Data data;
   setDataBlocksInData(buffer, data);
@@ -57,14 +50,14 @@ ParseData::parseUDPSequence(const datastructure::PacketBuffer& buffer) const
 }
 
 bool ParseData::parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                                 sick::datastructure::Data& data) const
+                                 sick::datastructure::Data& data)
 {
   setDataBlocksInData(buffer, data);
   return true;
 }
 
 void ParseData::setDataBlocksInData(const datastructure::PacketBuffer& buffer,
-                                    datastructure::Data& data) const
+                                    datastructure::Data& data)
 {
   setDataHeaderInData(buffer, data);
   setDerivedValuesInData(buffer, data);
@@ -75,52 +68,53 @@ void ParseData::setDataBlocksInData(const datastructure::PacketBuffer& buffer,
 }
 
 void ParseData::setDataHeaderInData(const datastructure::PacketBuffer& buffer,
-                                    datastructure::Data& data) const
+                                    datastructure::Data& data)
 {
   sick::datastructure::DataHeader data_header =
-    m_data_header_parser_ptr->parseUDPSequence(buffer, data);
+    sick::data_processing::ParseDataHeader::parseUDPSequence(buffer, data);
   data.setDataHeaderPtr(std::make_shared<sick::datastructure::DataHeader>(data_header));
 }
 
 void ParseData::setDerivedValuesInData(const datastructure::PacketBuffer& buffer,
-                                       datastructure::Data& data) const
+                                       datastructure::Data& data)
 {
   sick::datastructure::DerivedValues derived_values =
-    m_derived_values_parser_ptr->parseUDPSequence(buffer, data);
+    sick::data_processing::ParseDerivedValues::parseUDPSequence(buffer, data);
   data.setDerivedValuesPtr(std::make_shared<sick::datastructure::DerivedValues>(derived_values));
 }
 
 void ParseData::setMeasurementDataInData(const datastructure::PacketBuffer& buffer,
-                                         datastructure::Data& data) const
+                                         datastructure::Data& data)
 {
   sick::datastructure::MeasurementData measurement_data =
-    m_measurement_data_parser_ptr->parseUDPSequence(buffer, data);
+    sick::data_processing::ParseMeasurementData::parseUDPSequence(buffer, data);
   data.setMeasurementDataPtr(
     std::make_shared<sick::datastructure::MeasurementData>(measurement_data));
 }
 
 void ParseData::setGeneralSystemStateInData(const datastructure::PacketBuffer& buffer,
-                                            datastructure::Data& data) const
+                                            datastructure::Data& data)
 {
   sick::datastructure::GeneralSystemState general_system_state =
-    m_general_system_state_parser_ptr->parseUDPSequence(buffer, data);
+    sick::data_processing::ParseGeneralSystemState::parseUDPSequence(buffer, data);
   data.setGeneralSystemStatePtr(
     std::make_shared<sick::datastructure::GeneralSystemState>(general_system_state));
 }
 
 void ParseData::setIntrusionDataInData(const datastructure::PacketBuffer& buffer,
-                                       datastructure::Data& data) const
+                                       datastructure::Data& data)
 {
   sick::datastructure::IntrusionData intrusion_data =
-    m_intrusion_data_parser_ptr->parseUDPSequence(buffer, data);
+    sick::data_processing::ParseIntrusionData::parseUDPSequence(buffer, data);
   data.setIntrusionDataPtr(std::make_shared<sick::datastructure::IntrusionData>(intrusion_data));
 }
 
 void ParseData::setApplicationDataInData(const datastructure::PacketBuffer& buffer,
-                                         datastructure::Data& data) const
+                                         datastructure::Data& data)
 {
   sick::datastructure::ApplicationData application_data =
-    m_application_data_parser_ptr->parseUDPSequence(buffer, data);
+    sick::data_processing::ParseApplicationData::parseUDPSequence(buffer, data);
+
   data.setApplicationDataPtr(
     std::make_shared<sick::datastructure::ApplicationData>(application_data));
 }

--- a/src/data_processing/ParseDataHeader.cpp
+++ b/src/data_processing/ParseDataHeader.cpp
@@ -41,7 +41,7 @@ ParseDataHeader::ParseDataHeader() {}
 
 datastructure::DataHeader
 ParseDataHeader::parseUDPSequence(const datastructure::PacketBuffer& buffer,
-                                  datastructure::Data& data) const
+                                  datastructure::Data& data)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -52,7 +52,7 @@ ParseDataHeader::parseUDPSequence(const datastructure::PacketBuffer& buffer,
 }
 
 void ParseDataHeader::setDataInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                          datastructure::DataHeader& data_header) const
+                                          datastructure::DataHeader& data_header)
 {
   setVersionInDataHeader(data_ptr, data_header);
   setScanHeaderInDataHeader(data_ptr, data_header);
@@ -61,7 +61,7 @@ void ParseDataHeader::setDataInDataHeader(std::vector<uint8_t>::const_iterator d
 
 
 void ParseDataHeader::setVersionInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                             datastructure::DataHeader& data_header) const
+                                             datastructure::DataHeader& data_header)
 {
   setVersionIndicatorInDataHeader(data_ptr, data_header);
   setMajorVersionInDataHeader(data_ptr, data_header);
@@ -72,7 +72,7 @@ void ParseDataHeader::setVersionInDataHeader(std::vector<uint8_t>::const_iterato
 }
 
 void ParseDataHeader::setScanHeaderInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                datastructure::DataHeader& data_header) const
+                                                datastructure::DataHeader& data_header)
 {
   setChannelNumberInDataHeader(data_ptr, data_header);
   setSequenceNumberInDataHeader(data_ptr, data_header);
@@ -82,7 +82,7 @@ void ParseDataHeader::setScanHeaderInDataHeader(std::vector<uint8_t>::const_iter
 }
 
 void ParseDataHeader::setDataBlocksInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                datastructure::DataHeader& data_header) const
+                                                datastructure::DataHeader& data_header)
 {
   setGeneralSystemStateBlockOffsetInDataHeader(data_ptr, data_header);
   setGeneralSystemStateBlockSizeInDataHeader(data_ptr, data_header);
@@ -97,131 +97,131 @@ void ParseDataHeader::setDataBlocksInDataHeader(std::vector<uint8_t>::const_iter
 }
 
 void ParseDataHeader::setVersionIndicatorInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                      datastructure::DataHeader& data_header) const
+                                                      datastructure::DataHeader& data_header)
 {
   data_header.setVersionIndicator(read_write_helper::readUint8LittleEndian(data_ptr + 0));
 }
 
 void ParseDataHeader::setMajorVersionInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                  datastructure::DataHeader& data_header) const
+                                                  datastructure::DataHeader& data_header)
 {
   data_header.setVersionMajorVersion(read_write_helper::readUint8LittleEndian(data_ptr + 1));
 }
 
 void ParseDataHeader::setMinorVersionInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                  datastructure::DataHeader& data_header) const
+                                                  datastructure::DataHeader& data_header)
 {
   data_header.setVersionMinorVersion(read_write_helper::readUint8LittleEndian(data_ptr + 2));
 }
 
 void ParseDataHeader::setVersionReleaseInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                    datastructure::DataHeader& data_header) const
+                                                    datastructure::DataHeader& data_header)
 {
   data_header.setVersionRelease(read_write_helper::readUint8LittleEndian(data_ptr + 3));
 }
 
 void ParseDataHeader::setSerialNumberOfDeviceInDataHeader(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header)
 {
   data_header.setSerialNumberOfDevice(read_write_helper::readUint32LittleEndian(data_ptr + 4));
 }
 
 void ParseDataHeader::setSerialNumberOfSystemPlugInDataHeader(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header)
 {
   data_header.setSerialNumberOfSystemPlug(read_write_helper::readUint32LittleEndian(data_ptr + 8));
 }
 
 void ParseDataHeader::setChannelNumberInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                   datastructure::DataHeader& data_header) const
+                                                   datastructure::DataHeader& data_header)
 {
   data_header.setChannelNumber(read_write_helper::readUint8LittleEndian(data_ptr + 12));
 }
 
 void ParseDataHeader::setSequenceNumberInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                    datastructure::DataHeader& data_header) const
+                                                    datastructure::DataHeader& data_header)
 {
   data_header.setSequenceNumber(read_write_helper::readUint32LittleEndian(data_ptr + 16));
 }
 
 void ParseDataHeader::setScanNumberInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                datastructure::DataHeader& data_header) const
+                                                datastructure::DataHeader& data_header)
 {
   data_header.setScanNumber(read_write_helper::readUint32LittleEndian(data_ptr + 20));
 }
 
 void ParseDataHeader::setTimestampDateInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                   datastructure::DataHeader& data_header) const
+                                                   datastructure::DataHeader& data_header)
 {
   data_header.setTimestampDate(read_write_helper::readUint16LittleEndian(data_ptr + 24));
 }
 
 void ParseDataHeader::setTimestampTimeInDataHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                   datastructure::DataHeader& data_header) const
+                                                   datastructure::DataHeader& data_header)
 {
   data_header.setTimestampTime(read_write_helper::readUint32LittleEndian(data_ptr + 28));
 }
 
 void ParseDataHeader::setGeneralSystemStateBlockOffsetInDataHeader(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header)
 {
   data_header.setGeneralSystemStateBlockOffset(
     read_write_helper::readUint16LittleEndian(data_ptr + 32));
 }
 
 void ParseDataHeader::setGeneralSystemStateBlockSizeInDataHeader(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header)
 {
   data_header.setGeneralSystemStateBlockSize(
     read_write_helper::readUint16LittleEndian(data_ptr + 34));
 }
 
 void ParseDataHeader::setDerivedValuesBlockOffsetInDataHeader(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header)
 {
   data_header.setDerivedValuesBlockOffset(read_write_helper::readUint16LittleEndian(data_ptr + 36));
 }
 
 void ParseDataHeader::setDerivedValuesBlockSizeInDataHeader(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header)
 {
   data_header.setDerivedValuesBlockSize(read_write_helper::readUint16LittleEndian(data_ptr + 38));
 }
 
 void ParseDataHeader::setMeasurementDataBlockOffsetInDataHeader(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header)
 {
   data_header.setMeasurementDataBlockOffset(
     read_write_helper::readUint16LittleEndian(data_ptr + 40));
 }
 
 void ParseDataHeader::setMeasurementDataBlockSizeInDataHeader(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header)
 {
   data_header.setMeasurementDataBlockSize(read_write_helper::readUint16LittleEndian(data_ptr + 42));
 }
 
 void ParseDataHeader::setIntrusionDataBlockOffsetInDataHeader(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header)
 {
   data_header.setIntrusionDataBlockOffset(read_write_helper::readUint16LittleEndian(data_ptr + 44));
 }
 
 void ParseDataHeader::setIntrusionDataBlockSizeInDataHeader(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header)
 {
   data_header.setIntrusionDataBlockSize(read_write_helper::readUint16LittleEndian(data_ptr + 46));
 }
 
 void ParseDataHeader::setApplicationDataBlockOffsetInDataHeader(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header)
 {
   data_header.setApplicationDataBlockOffset(
     read_write_helper::readUint16LittleEndian(data_ptr + 48));
 }
 
 void ParseDataHeader::setApplicationDataBlockSizeInDataHeader(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DataHeader& data_header)
 {
   data_header.setApplicationDataBlockSize(read_write_helper::readUint16LittleEndian(data_ptr + 50));
 }

--- a/src/data_processing/ParseDatagramHeader.cpp
+++ b/src/data_processing/ParseDatagramHeader.cpp
@@ -40,7 +40,7 @@ namespace data_processing {
 ParseDatagramHeader::ParseDatagramHeader() {}
 
 bool ParseDatagramHeader::parseUDPSequence(const datastructure::PacketBuffer& buffer,
-                                           datastructure::DatagramHeader& header) const
+                                           datastructure::DatagramHeader& header)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -50,7 +50,7 @@ bool ParseDatagramHeader::parseUDPSequence(const datastructure::PacketBuffer& bu
 }
 
 void ParseDatagramHeader::setDataInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                          datastructure::DatagramHeader& header) const
+                                          datastructure::DatagramHeader& header)
 {
   setDatagramMarkerInHeader(data_ptr, header);
   setProtocolInHeader(data_ptr, header);
@@ -62,43 +62,43 @@ void ParseDatagramHeader::setDataInHeader(std::vector<uint8_t>::const_iterator d
 }
 
 void ParseDatagramHeader::setDatagramMarkerInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                    datastructure::DatagramHeader& header) const
+                                                    datastructure::DatagramHeader& header)
 {
   header.setDatagramMarker(read_write_helper::readUint32BigEndian(data_ptr + 0));
 }
 
 void ParseDatagramHeader::setProtocolInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                              datastructure::DatagramHeader& header) const
+                                              datastructure::DatagramHeader& header)
 {
   header.setProtocol(read_write_helper::readUint16BigEndian(data_ptr + 4));
 }
 
 void ParseDatagramHeader::setMajorVersionInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                  datastructure::DatagramHeader& header) const
+                                                  datastructure::DatagramHeader& header)
 {
   header.setMajorVersion(read_write_helper::readUint8LittleEndian(data_ptr + 6));
 }
 
 void ParseDatagramHeader::setMinorVersionInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                  datastructure::DatagramHeader& header) const
+                                                  datastructure::DatagramHeader& header)
 {
   header.setMinorVersion(read_write_helper::readUint8LittleEndian(data_ptr + 7));
 }
 
 void ParseDatagramHeader::setTotalLengthInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                 datastructure::DatagramHeader& header) const
+                                                 datastructure::DatagramHeader& header)
 {
   header.setTotalLength(read_write_helper::readUint32LittleEndian(data_ptr + 8));
 }
 
 void ParseDatagramHeader::setIdentificationInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                    datastructure::DatagramHeader& header) const
+                                                    datastructure::DatagramHeader& header)
 {
   header.setIdentification(read_write_helper::readUint32LittleEndian(data_ptr + 12));
 }
 
 void ParseDatagramHeader::setFragmentOffsetInHeader(std::vector<uint8_t>::const_iterator data_ptr,
-                                                    datastructure::DatagramHeader& header) const
+                                                    datastructure::DatagramHeader& header)
 {
   header.setFragmentOffset(read_write_helper::readUint32LittleEndian(data_ptr + 16));
 }

--- a/src/data_processing/ParseDerivedValues.cpp
+++ b/src/data_processing/ParseDerivedValues.cpp
@@ -41,7 +41,7 @@ ParseDerivedValues::ParseDerivedValues() {}
 
 datastructure::DerivedValues
 ParseDerivedValues::parseUDPSequence(const datastructure::PacketBuffer& buffer,
-                                     datastructure::Data& data) const
+                                     datastructure::Data& data)
 {
   datastructure::DerivedValues derived_values;
 
@@ -59,7 +59,7 @@ ParseDerivedValues::parseUDPSequence(const datastructure::PacketBuffer& buffer,
   return derived_values;
 }
 
-bool ParseDerivedValues::checkIfPreconditionsAreMet(const datastructure::Data& data) const
+bool ParseDerivedValues::checkIfPreconditionsAreMet(const datastructure::Data& data)
 {
   if (!checkIfDerivedValuesIsPublished(data))
   {
@@ -73,20 +73,20 @@ bool ParseDerivedValues::checkIfPreconditionsAreMet(const datastructure::Data& d
   return true;
 }
 
-bool ParseDerivedValues::checkIfDerivedValuesIsPublished(const datastructure::Data& data) const
+bool ParseDerivedValues::checkIfDerivedValuesIsPublished(const datastructure::Data& data)
 {
   return !(data.getDataHeaderPtr()->getDerivedValuesBlockOffset() == 0 &&
            data.getDataHeaderPtr()->getDerivedValuesBlockSize() == 0);
 }
 
 bool ParseDerivedValues::checkIfDataContainsNeededParsedBlocks(
-  const datastructure::Data& data) const
+  const datastructure::Data& data)
 {
   return !(data.getDataHeaderPtr()->isEmpty());
 }
 
 void ParseDerivedValues::setDataInDerivedValues(std::vector<uint8_t>::const_iterator data_ptr,
-                                                datastructure::DerivedValues& derived_values) const
+                                                datastructure::DerivedValues& derived_values)
 {
   setMultiplicationFactorInDerivedValues(data_ptr, derived_values);
   setNumberOfBeamsInDerivedValues(data_ptr, derived_values);
@@ -97,37 +97,37 @@ void ParseDerivedValues::setDataInDerivedValues(std::vector<uint8_t>::const_iter
 }
 
 void ParseDerivedValues::setMultiplicationFactorInDerivedValues(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DerivedValues& derived_values) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DerivedValues& derived_values)
 {
   derived_values.setMultiplicationFactor(read_write_helper::readUint16LittleEndian(data_ptr + 0));
 }
 
 void ParseDerivedValues::setNumberOfBeamsInDerivedValues(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DerivedValues& derived_values) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DerivedValues& derived_values)
 {
   derived_values.setNumberOfBeams(read_write_helper::readUint16LittleEndian(data_ptr + 2));
 }
 
 void ParseDerivedValues::setScanTimeInDerivedValues(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DerivedValues& derived_values) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DerivedValues& derived_values)
 {
   derived_values.setScanTime(read_write_helper::readUint16LittleEndian(data_ptr + 4));
 }
 
 void ParseDerivedValues::setStartAngleInDerivedValues(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DerivedValues& derived_values) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DerivedValues& derived_values)
 {
   derived_values.setStartAngle(read_write_helper::readInt32LittleEndian(data_ptr + 8));
 }
 
 void ParseDerivedValues::setAngularBeamResolutionInDerivedValues(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DerivedValues& derived_values) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DerivedValues& derived_values)
 {
   derived_values.setAngularBeamResolution(read_write_helper::readInt32LittleEndian(data_ptr + 12));
 }
 
 void ParseDerivedValues::setInterbeamPeriodInDerivedValues(
-  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DerivedValues& derived_values) const
+  std::vector<uint8_t>::const_iterator data_ptr, datastructure::DerivedValues& derived_values)
 {
   derived_values.setInterbeamPeriod(read_write_helper::readUint32LittleEndian(data_ptr + 16));
 }

--- a/src/data_processing/ParseDeviceName.cpp
+++ b/src/data_processing/ParseDeviceName.cpp
@@ -43,7 +43,7 @@ ParseDeviceName::ParseDeviceName() {}
 
 
 bool ParseDeviceName::parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                                       datastructure::DeviceName& device_name) const
+                                       datastructure::DeviceName& device_name)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -53,7 +53,7 @@ bool ParseDeviceName::parseTCPSequence(const datastructure::PacketBuffer& buffer
 }
 
 
-std::string ParseDeviceName::readDeviceName(std::vector<uint8_t>::const_iterator data_ptr) const
+std::string ParseDeviceName::readDeviceName(std::vector<uint8_t>::const_iterator data_ptr)
 {
   uint16_t string_length = read_write_helper::readUint16LittleEndian(data_ptr + 0);
 

--- a/src/data_processing/ParseDeviceStatus.cpp
+++ b/src/data_processing/ParseDeviceStatus.cpp
@@ -43,7 +43,7 @@ ParseDeviceStatusData::ParseDeviceStatusData() {}
 
 
 bool ParseDeviceStatusData::parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                                             sick::datastructure::DeviceStatus& device_status) const
+                                             sick::datastructure::DeviceStatus& device_status)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -52,7 +52,7 @@ bool ParseDeviceStatusData::parseTCPSequence(const datastructure::PacketBuffer& 
   return true;
 }
 
-uint8_t ParseDeviceStatusData::readDeviceStatus(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseDeviceStatusData::readDeviceStatus(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 0);
 }

--- a/src/data_processing/ParseFieldGeometryData.cpp
+++ b/src/data_processing/ParseFieldGeometryData.cpp
@@ -43,7 +43,7 @@ ParseFieldGeometryData::ParseFieldGeometryData() {}
 
 
 bool ParseFieldGeometryData::parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                                              sick::datastructure::FieldData& field_data) const
+                                              sick::datastructure::FieldData& field_data)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -60,13 +60,13 @@ bool ParseFieldGeometryData::parseTCPSequence(const datastructure::PacketBuffer&
 }
 
 uint32_t
-ParseFieldGeometryData::readArrayLength(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseFieldGeometryData::readArrayLength(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 4);
 }
 
 uint16_t ParseFieldGeometryData::readArrayElement(std::vector<uint8_t>::const_iterator data_ptr,
-                                                  uint32_t elem_number) const
+                                                  uint32_t elem_number)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 8 + elem_number * 2);
 }

--- a/src/data_processing/ParseFieldHeaderData.cpp
+++ b/src/data_processing/ParseFieldHeaderData.cpp
@@ -43,7 +43,7 @@ ParseFieldHeaderData::ParseFieldHeaderData() {}
 
 
 bool ParseFieldHeaderData::parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                                            datastructure::FieldData& field_data) const
+                                            datastructure::FieldData& field_data)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -70,7 +70,7 @@ bool ParseFieldHeaderData::parseTCPSequence(const datastructure::PacketBuffer& b
   return true;
 }
 
-bool ParseFieldHeaderData::isValid(std::vector<uint8_t>::const_iterator data_ptr) const
+bool ParseFieldHeaderData::isValid(std::vector<uint8_t>::const_iterator data_ptr)
 {
   bool res     = false;
   uint8_t byte = read_write_helper::readUint8(data_ptr + 0);
@@ -83,7 +83,7 @@ bool ParseFieldHeaderData::isValid(std::vector<uint8_t>::const_iterator data_ptr
 }
 
 void ParseFieldHeaderData::setFieldType(std::vector<uint8_t>::const_iterator data_ptr,
-                                        datastructure::FieldData& field_data) const
+                                        datastructure::FieldData& field_data)
 {
   uint8_t field_type = readEvalMethod(data_ptr);
   field_data.setIsWarningField(false);
@@ -99,65 +99,65 @@ void ParseFieldHeaderData::setFieldType(std::vector<uint8_t>::const_iterator dat
 }
 
 std::string
-ParseFieldHeaderData::readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseFieldHeaderData::readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr)
 {
   std::string result;
   result.push_back(read_write_helper::readUint8(data_ptr + 0));
   return result;
 }
 
-uint8_t ParseFieldHeaderData::readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseFieldHeaderData::readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 1);
 }
 
-uint8_t ParseFieldHeaderData::readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseFieldHeaderData::readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 2);
 }
 
-uint8_t ParseFieldHeaderData::readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseFieldHeaderData::readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 3);
 }
 
-bool ParseFieldHeaderData::readIsDefined(std::vector<uint8_t>::const_iterator data_ptr) const
+bool ParseFieldHeaderData::readIsDefined(std::vector<uint8_t>::const_iterator data_ptr)
 {
   // TODO
   return read_write_helper::readUint8(data_ptr + 72);
 }
 
-uint8_t ParseFieldHeaderData::readEvalMethod(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseFieldHeaderData::readEvalMethod(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 73);
 }
 
 
 uint16_t
-ParseFieldHeaderData::readMultiSampling(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseFieldHeaderData::readMultiSampling(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 74);
 }
 
 uint16_t
-ParseFieldHeaderData::readObjectResolution(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseFieldHeaderData::readObjectResolution(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 78);
 }
 
-uint16_t ParseFieldHeaderData::readSetIndex(std::vector<uint8_t>::const_iterator data_ptr) const
+uint16_t ParseFieldHeaderData::readSetIndex(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 82);
 }
 
 
-uint32_t ParseFieldHeaderData::readNameLength(std::vector<uint8_t>::const_iterator data_ptr) const
+uint32_t ParseFieldHeaderData::readNameLength(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 84);
 }
 
 
-std::string ParseFieldHeaderData::readFieldName(std::vector<uint8_t>::const_iterator data_ptr) const
+std::string ParseFieldHeaderData::readFieldName(std::vector<uint8_t>::const_iterator data_ptr)
 {
   uint32_t name_length = read_write_helper::readUint32LittleEndian(data_ptr + 84);
   std::string name;

--- a/src/data_processing/ParseFieldSetsData.cpp
+++ b/src/data_processing/ParseFieldSetsData.cpp
@@ -43,7 +43,7 @@ ParseFieldSetsData::ParseFieldSetsData() {}
 
 
 bool ParseFieldSetsData::parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                                          sick::datastructure::FieldSets& field_sets) const
+                                          sick::datastructure::FieldSets& field_sets)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -60,29 +60,29 @@ bool ParseFieldSetsData::parseTCPSequence(const datastructure::PacketBuffer& buf
 }
 
 std::string
-ParseFieldSetsData::readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseFieldSetsData::readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr)
 {
   std::string result;
   result.push_back(read_write_helper::readUint8(data_ptr + 0));
   return result;
 }
 
-uint8_t ParseFieldSetsData::readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseFieldSetsData::readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 1);
 }
 
-uint8_t ParseFieldSetsData::readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseFieldSetsData::readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 2);
 }
 
-uint8_t ParseFieldSetsData::readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseFieldSetsData::readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 3);
 }
 
-uint32_t ParseFieldSetsData::readArrayLength(std::vector<uint8_t>::const_iterator data_ptr) const
+uint32_t ParseFieldSetsData::readArrayLength(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 4);
 }
@@ -90,7 +90,7 @@ uint32_t ParseFieldSetsData::readArrayLength(std::vector<uint8_t>::const_iterato
 
 std::vector<std::string>
 ParseFieldSetsData::readFieldName(std::vector<uint8_t>::const_iterator data_ptr,
-                                  uint32_t array_length) const
+                                  uint32_t array_length)
 {
   std::vector<std::string> result;
   for (uint32_t i = 0; i < array_length; i++)
@@ -108,7 +108,7 @@ ParseFieldSetsData::readFieldName(std::vector<uint8_t>::const_iterator data_ptr,
 
 std::vector<uint32_t>
 ParseFieldSetsData::readNameLength(std::vector<uint8_t>::const_iterator data_ptr,
-                                   uint32_t array_length) const
+                                   uint32_t array_length)
 {
   std::vector<uint32_t> result;
   for (uint32_t i = 0; i < array_length; i++)
@@ -118,7 +118,7 @@ ParseFieldSetsData::readNameLength(std::vector<uint8_t>::const_iterator data_ptr
   return result;
 }
 std::vector<bool> ParseFieldSetsData::readIsDefined(std::vector<uint8_t>::const_iterator data_ptr,
-                                                    uint32_t array_length) const
+                                                    uint32_t array_length)
 {
   std::vector<bool> result;
   for (uint32_t i = 0; i < array_length; i++)

--- a/src/data_processing/ParseFirmwareVersion.cpp
+++ b/src/data_processing/ParseFirmwareVersion.cpp
@@ -43,7 +43,7 @@ ParseFirmwareVersion::ParseFirmwareVersion() {}
 
 
 bool ParseFirmwareVersion::parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                                            datastructure::FirmwareVersion& firmware_version) const
+                                            datastructure::FirmwareVersion& firmware_version)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -54,7 +54,7 @@ bool ParseFirmwareVersion::parseTCPSequence(const datastructure::PacketBuffer& b
 
 
 std::string
-ParseFirmwareVersion::readFirmwareVersion(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseFirmwareVersion::readFirmwareVersion(std::vector<uint8_t>::const_iterator data_ptr)
 {
   uint16_t string_length = read_write_helper::readUint16LittleEndian(data_ptr + 0);
 

--- a/src/data_processing/ParseGeneralSystemState.cpp
+++ b/src/data_processing/ParseGeneralSystemState.cpp
@@ -41,7 +41,7 @@ ParseGeneralSystemState::ParseGeneralSystemState() {}
 
 datastructure::GeneralSystemState
 ParseGeneralSystemState::parseUDPSequence(const datastructure::PacketBuffer& buffer,
-                                          datastructure::Data& data) const
+                                          datastructure::Data& data)
 {
   datastructure::GeneralSystemState general_system_state;
   if (!checkIfPreconditionsAreMet(data))
@@ -58,7 +58,7 @@ ParseGeneralSystemState::parseUDPSequence(const datastructure::PacketBuffer& buf
   return general_system_state;
 }
 
-bool ParseGeneralSystemState::checkIfPreconditionsAreMet(const datastructure::Data& data) const
+bool ParseGeneralSystemState::checkIfPreconditionsAreMet(const datastructure::Data& data)
 {
   if (!checkIfGeneralSystemStateIsPublished(data))
   {
@@ -73,14 +73,14 @@ bool ParseGeneralSystemState::checkIfPreconditionsAreMet(const datastructure::Da
 }
 
 bool ParseGeneralSystemState::checkIfGeneralSystemStateIsPublished(
-  const datastructure::Data& data) const
+  const datastructure::Data& data)
 {
   return !(data.getDataHeaderPtr()->getGeneralSystemStateBlockOffset() == 0 &&
            data.getDataHeaderPtr()->getGeneralSystemStateBlockSize() == 0);
 }
 
 bool ParseGeneralSystemState::checkIfDataContainsNeededParsedBlocks(
-  const datastructure::Data& data) const
+  const datastructure::Data& data)
 {
   return !(data.getDataHeaderPtr()->isEmpty());
 }
@@ -88,7 +88,7 @@ bool ParseGeneralSystemState::checkIfDataContainsNeededParsedBlocks(
 
 void ParseGeneralSystemState::setDataInGeneralSystemState(
   std::vector<uint8_t>::const_iterator data_ptr,
-  datastructure::GeneralSystemState& general_system_state) const
+  datastructure::GeneralSystemState& general_system_state)
 {
   setStatusBitsInGeneralSystemState(data_ptr, general_system_state);
   setSafeCutOffPathInGeneralSystemState(data_ptr, general_system_state);
@@ -100,7 +100,7 @@ void ParseGeneralSystemState::setDataInGeneralSystemState(
 
 void ParseGeneralSystemState::setStatusBitsInGeneralSystemState(
   std::vector<uint8_t>::const_iterator data_ptr,
-  datastructure::GeneralSystemState& general_system_state) const
+  datastructure::GeneralSystemState& general_system_state)
 {
   uint8_t byte = read_write_helper::readUint8LittleEndian(data_ptr + 0);
 
@@ -115,7 +115,7 @@ void ParseGeneralSystemState::setStatusBitsInGeneralSystemState(
 
 void ParseGeneralSystemState::setSafeCutOffPathInGeneralSystemState(
   std::vector<uint8_t>::const_iterator data_ptr,
-  datastructure::GeneralSystemState& general_system_state) const
+  datastructure::GeneralSystemState& general_system_state)
 {
   std::vector<bool> safe_cut_off_path;
 
@@ -138,7 +138,7 @@ void ParseGeneralSystemState::setSafeCutOffPathInGeneralSystemState(
 
 void ParseGeneralSystemState::setNonSafeCutOffPathInGeneralSystemState(
   std::vector<uint8_t>::const_iterator data_ptr,
-  datastructure::GeneralSystemState& general_system_state) const
+  datastructure::GeneralSystemState& general_system_state)
 {
   std::vector<bool> non_safe_cut_off_path;
 
@@ -161,7 +161,7 @@ void ParseGeneralSystemState::setNonSafeCutOffPathInGeneralSystemState(
 
 void ParseGeneralSystemState::setResetRequiredCutOffPathInGeneralSystemState(
   std::vector<uint8_t>::const_iterator data_ptr,
-  datastructure::GeneralSystemState& general_system_state) const
+  datastructure::GeneralSystemState& general_system_state)
 {
   std::vector<bool> reset_required_cutoff_path;
 
@@ -184,7 +184,7 @@ void ParseGeneralSystemState::setResetRequiredCutOffPathInGeneralSystemState(
 
 void ParseGeneralSystemState::setCurrentMonitoringCasesInGeneralSystemState(
   std::vector<uint8_t>::const_iterator data_ptr,
-  datastructure::GeneralSystemState& general_system_state) const
+  datastructure::GeneralSystemState& general_system_state)
 {
   general_system_state.setCurrentMonitoringCaseNoTable1(
     read_write_helper::readUint8LittleEndian(data_ptr + 10));
@@ -198,7 +198,7 @@ void ParseGeneralSystemState::setCurrentMonitoringCasesInGeneralSystemState(
 
 void ParseGeneralSystemState::setErrorsInGeneralSystemState(
   std::vector<uint8_t>::const_iterator data_ptr,
-  datastructure::GeneralSystemState& general_system_state) const
+  datastructure::GeneralSystemState& general_system_state)
 {
   uint8_t byte = read_write_helper::readUint8LittleEndian(data_ptr + 15);
   general_system_state.setApplicationError(static_cast<bool>(byte & (0x01 << 0)));

--- a/src/data_processing/ParseMeasurementCurrentConfigData.cpp
+++ b/src/data_processing/ParseMeasurementCurrentConfigData.cpp
@@ -43,7 +43,7 @@ ParseMeasurementCurrentConfigData::ParseMeasurementCurrentConfigData() {}
 
 
 bool ParseMeasurementCurrentConfigData::parseTCPSequence(
-  const datastructure::PacketBuffer& buffer, datastructure::ConfigData& config_data) const
+  const datastructure::PacketBuffer& buffer, datastructure::ConfigData& config_data)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -70,7 +70,7 @@ bool ParseMeasurementCurrentConfigData::parseTCPSequence(
 }
 
 std::string ParseMeasurementCurrentConfigData::readVersionIndicator(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   std::string result;
   result.push_back(read_write_helper::readUint8(data_ptr + 0));
@@ -78,37 +78,37 @@ std::string ParseMeasurementCurrentConfigData::readVersionIndicator(
 }
 
 uint8_t ParseMeasurementCurrentConfigData::readMajorNumber(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 1);
 }
 
 uint8_t ParseMeasurementCurrentConfigData::readMinorNumber(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 2);
 }
 
 uint8_t ParseMeasurementCurrentConfigData::readReleaseNumber(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 3);
 }
 
 bool ParseMeasurementCurrentConfigData::readEnabled(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 4);
 }
 
 uint8_t ParseMeasurementCurrentConfigData::readInterfaceType(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 5);
 }
 
 boost::asio::ip::address_v4
-ParseMeasurementCurrentConfigData::readHostIp(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseMeasurementCurrentConfigData::readHostIp(std::vector<uint8_t>::const_iterator data_ptr)
 {
   uint32_t word = read_write_helper::readUint32LittleEndian(data_ptr + 8);
   boost::asio::ip::address_v4 addr(word);
@@ -116,68 +116,68 @@ ParseMeasurementCurrentConfigData::readHostIp(std::vector<uint8_t>::const_iterat
 }
 
 uint16_t
-ParseMeasurementCurrentConfigData::readHostPort(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseMeasurementCurrentConfigData::readHostPort(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 12);
 }
 
 uint16_t ParseMeasurementCurrentConfigData::readPublishingFreq(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 14);
 }
 
 uint32_t ParseMeasurementCurrentConfigData::readStartAngle(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 16);
 }
 
 uint32_t
-ParseMeasurementCurrentConfigData::readEndAngle(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseMeasurementCurrentConfigData::readEndAngle(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 20);
 }
 
 uint16_t
-ParseMeasurementCurrentConfigData::readFeatures(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseMeasurementCurrentConfigData::readFeatures(std::vector<uint8_t>::const_iterator data_ptr)
 {
   // TODO parse Features
   return read_write_helper::readUint16LittleEndian(data_ptr + 24);
 }
 
 uint16_t ParseMeasurementCurrentConfigData::readDerivedMultiplicationFactor(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 28);
 }
 
 uint16_t ParseMeasurementCurrentConfigData::readDerivedNumBeams(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 30);
 }
 
 uint16_t ParseMeasurementCurrentConfigData::readDerivedScanTime(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 32);
 }
 
 uint32_t ParseMeasurementCurrentConfigData::readDerivedStartAngle(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 36);
 }
 
 uint32_t ParseMeasurementCurrentConfigData::readDerivedAngularBeamResolution(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 40);
 }
 
 uint32_t ParseMeasurementCurrentConfigData::readDerivedInterbeamPeriod(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 44);
 }

--- a/src/data_processing/ParseMeasurementData.cpp
+++ b/src/data_processing/ParseMeasurementData.cpp
@@ -54,12 +54,14 @@ ParseMeasurementData::parseUDPSequence(const datastructure::PacketBuffer& buffer
   std::vector<uint8_t>::const_iterator data_ptr =
     vec_ptr->begin() + data.getDataHeaderPtr()->getMeasurementDataBlockOffset();
 
-  setStartAngleAndDelta(data);
-  setDataInMeasurementData(data_ptr, measurement_data);
+  const float angle       = data.getDerivedValuesPtr()->getStartAngle();
+  const float angle_delta = data.getDerivedValuesPtr()->getAngularBeamResolution();
+
+  setDataInMeasurementData(angle, angle_delta, data_ptr, measurement_data);
   return measurement_data;
 }
 
-bool ParseMeasurementData::checkIfPreconditionsAreMet(const datastructure::Data& data) const
+bool ParseMeasurementData::checkIfPreconditionsAreMet(const datastructure::Data& data)
 {
   if (!checkIfMeasurementDataIsPublished(data))
   {
@@ -72,14 +74,14 @@ bool ParseMeasurementData::checkIfPreconditionsAreMet(const datastructure::Data&
   return true;
 }
 
-bool ParseMeasurementData::checkIfMeasurementDataIsPublished(const datastructure::Data& data) const
+bool ParseMeasurementData::checkIfMeasurementDataIsPublished(const datastructure::Data& data)
 {
   return !(data.getDataHeaderPtr()->getMeasurementDataBlockOffset() == 0 &&
            data.getDataHeaderPtr()->getMeasurementDataBlockSize() == 0);
 }
 
 bool ParseMeasurementData::checkIfDataContainsNeededParsedBlocks(
-  const datastructure::Data& data) const
+  const datastructure::Data& data)
 {
   if (data.getDataHeaderPtr()->isEmpty())
   {
@@ -92,41 +94,40 @@ bool ParseMeasurementData::checkIfDataContainsNeededParsedBlocks(
   return true;
 }
 
-
 void ParseMeasurementData::setDataInMeasurementData(
+  const float& angle,
+  const float& angle_delta,
   std::vector<uint8_t>::const_iterator data_ptr, datastructure::MeasurementData& measurement_data)
 {
   setNumberOfBeamsInMeasurementData(data_ptr, measurement_data);
-  setScanPointsInMeasurementData(data_ptr, measurement_data);
+  setScanPointsInMeasurementData(angle, angle_delta, data_ptr, measurement_data);
 }
 
 void ParseMeasurementData::setNumberOfBeamsInMeasurementData(
   std::vector<uint8_t>::const_iterator data_ptr,
-  datastructure::MeasurementData& measurement_data) const
+  datastructure::MeasurementData& measurement_data)
 {
   measurement_data.setNumberOfBeams(read_write_helper::readUint32LittleEndian(data_ptr + 0));
 }
 
-void ParseMeasurementData::setStartAngleAndDelta(const datastructure::Data& data)
-{
-  m_angle       = data.getDerivedValuesPtr()->getStartAngle();
-  m_angle_delta = data.getDerivedValuesPtr()->getAngularBeamResolution();
-}
-
 void ParseMeasurementData::setScanPointsInMeasurementData(
+  const float& angle,
+  const float& angle_delta,
   std::vector<uint8_t>::const_iterator data_ptr, datastructure::MeasurementData& measurement_data)
 {
+  float cur_angle = angle;
   for (size_t i = 0; i < measurement_data.getNumberOfBeams(); i++)
   {
-    addScanPointToMeasurementData(i, data_ptr, measurement_data);
-    m_angle += m_angle_delta;
+    addScanPointToMeasurementData(i, cur_angle, data_ptr, measurement_data);
+    cur_angle += angle_delta;
   }
 }
 
 void ParseMeasurementData::addScanPointToMeasurementData(
   const uint16_t offset,
+  const float& angle,
   std::vector<uint8_t>::const_iterator data_ptr,
-  datastructure::MeasurementData& measurement_data) const
+  datastructure::MeasurementData& measurement_data)
 {
   uint16_t distance    = read_write_helper::readUint16LittleEndian(data_ptr + (4 + offset * 4));
   uint8_t reflectivity = read_write_helper::readUint8LittleEndian(data_ptr + (6 + offset * 4));
@@ -137,7 +138,8 @@ void ParseMeasurementData::addScanPointToMeasurementData(
   bool reflector       = static_cast<bool>(status & (0x01 << 3));
   bool contamination   = static_cast<bool>(status & (0x01 << 4));
   bool contamination_warning = static_cast<bool>(status & (0x01 << 5));
-  measurement_data.addScanPoint(sick::datastructure::ScanPoint(m_angle,
+
+  measurement_data.addScanPoint(sick::datastructure::ScanPoint(angle,
                                                                distance,
                                                                reflectivity,
                                                                valid,

--- a/src/data_processing/ParseMeasurementData.cpp
+++ b/src/data_processing/ParseMeasurementData.cpp
@@ -54,12 +54,14 @@ ParseMeasurementData::parseUDPSequence(const datastructure::PacketBuffer& buffer
   std::vector<uint8_t>::const_iterator data_ptr =
     vec_ptr->begin() + data.getDataHeaderPtr()->getMeasurementDataBlockOffset();
 
-  setStartAngleAndDelta(data);
-  setDataInMeasurementData(data_ptr, measurement_data);
+  const float angle       = data.getDerivedValuesPtr()->getStartAngle();
+  const float angle_delta = data.getDerivedValuesPtr()->getAngularBeamResolution();
+
+  setDataInMeasurementData(angle, angle_delta, data_ptr, measurement_data);
   return measurement_data;
 }
 
-bool ParseMeasurementData::checkIfPreconditionsAreMet(const datastructure::Data& data) const
+bool ParseMeasurementData::checkIfPreconditionsAreMet(const datastructure::Data& data)
 {
   if (!checkIfMeasurementDataIsPublished(data))
   {
@@ -72,14 +74,14 @@ bool ParseMeasurementData::checkIfPreconditionsAreMet(const datastructure::Data&
   return true;
 }
 
-bool ParseMeasurementData::checkIfMeasurementDataIsPublished(const datastructure::Data& data) const
+bool ParseMeasurementData::checkIfMeasurementDataIsPublished(const datastructure::Data& data)
 {
   return !(data.getDataHeaderPtr()->getMeasurementDataBlockOffset() == 0 &&
            data.getDataHeaderPtr()->getMeasurementDataBlockSize() == 0);
 }
 
 bool ParseMeasurementData::checkIfDataContainsNeededParsedBlocks(
-  const datastructure::Data& data) const
+  const datastructure::Data& data)
 {
   if (data.getDataHeaderPtr()->isEmpty())
   {
@@ -92,41 +94,40 @@ bool ParseMeasurementData::checkIfDataContainsNeededParsedBlocks(
   return true;
 }
 
-
 void ParseMeasurementData::setDataInMeasurementData(
+  const float& angle,
+  const float& angle_delta,
   std::vector<uint8_t>::const_iterator data_ptr, datastructure::MeasurementData& measurement_data)
 {
   setNumberOfBeamsInMeasurementData(data_ptr, measurement_data);
-  setScanPointsInMeasurementData(data_ptr, measurement_data);
+  setScanPointsInMeasurementData(angle, angle_delta, data_ptr, measurement_data);
 }
 
 void ParseMeasurementData::setNumberOfBeamsInMeasurementData(
   std::vector<uint8_t>::const_iterator data_ptr,
-  datastructure::MeasurementData& measurement_data) const
+  datastructure::MeasurementData& measurement_data)
 {
   measurement_data.setNumberOfBeams(read_write_helper::readUint32LittleEndian(data_ptr + 0));
 }
 
-void ParseMeasurementData::setStartAngleAndDelta(const datastructure::Data& data)
-{
-  m_angle       = data.getDerivedValuesPtr()->getStartAngle();
-  m_angle_delta = data.getDerivedValuesPtr()->getAngularBeamResolution();
-}
-
 void ParseMeasurementData::setScanPointsInMeasurementData(
+  const float& angle,
+  const float& angle_delta,
   std::vector<uint8_t>::const_iterator data_ptr, datastructure::MeasurementData& measurement_data)
 {
+  float cur_angle = angle;
   for (size_t i = 0; i < measurement_data.getNumberOfBeams(); i++)
   {
-    addScanPointToMeasurementData(i, data_ptr, measurement_data);
-    m_angle += m_angle_delta;
+    addScanPointToMeasurementData(i, cur_angle, data_ptr, measurement_data);
+    cur_angle += angle_delta;
   }
 }
 
 void ParseMeasurementData::addScanPointToMeasurementData(
   const uint16_t offset,
+  const float& angle,
   std::vector<uint8_t>::const_iterator data_ptr,
-  datastructure::MeasurementData& measurement_data) const
+  datastructure::MeasurementData& measurement_data)
 {
   int16_t distance     = read_write_helper::readUint16LittleEndian(data_ptr + (4 + offset * 4));
   uint8_t reflectivity = read_write_helper::readUint8LittleEndian(data_ptr + (6 + offset * 4));
@@ -137,7 +138,8 @@ void ParseMeasurementData::addScanPointToMeasurementData(
   bool reflector       = static_cast<bool>(status & (0x01 << 3));
   bool contamination   = static_cast<bool>(status & (0x01 << 4));
   bool contamination_warning = static_cast<bool>(status & (0x01 << 5));
-  measurement_data.addScanPoint(sick::datastructure::ScanPoint(m_angle,
+
+  measurement_data.addScanPoint(sick::datastructure::ScanPoint(angle,
                                                                distance,
                                                                reflectivity,
                                                                valid,

--- a/src/data_processing/ParseMeasurementPersistentConfigData.cpp
+++ b/src/data_processing/ParseMeasurementPersistentConfigData.cpp
@@ -43,7 +43,7 @@ ParseMeasurementPersistentConfigData::ParseMeasurementPersistentConfigData() {}
 
 
 bool ParseMeasurementPersistentConfigData::parseTCPSequence(
-  const datastructure::PacketBuffer& buffer, datastructure::ConfigData& config_data) const
+  const datastructure::PacketBuffer& buffer, datastructure::ConfigData& config_data)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -64,7 +64,7 @@ bool ParseMeasurementPersistentConfigData::parseTCPSequence(
 }
 
 std::string ParseMeasurementPersistentConfigData::readVersionIndicator(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   std::string result;
   result.push_back(read_write_helper::readUint8(data_ptr + 0));
@@ -72,37 +72,37 @@ std::string ParseMeasurementPersistentConfigData::readVersionIndicator(
 }
 
 uint8_t ParseMeasurementPersistentConfigData::readMajorNumber(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 1);
 }
 
 uint8_t ParseMeasurementPersistentConfigData::readMinorNumber(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 2);
 }
 
 uint8_t ParseMeasurementPersistentConfigData::readReleaseNumber(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 3);
 }
 
 bool ParseMeasurementPersistentConfigData::readEnabled(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 4);
 }
 
 uint8_t ParseMeasurementPersistentConfigData::readInterfaceType(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 5);
 }
 
 boost::asio::ip::address_v4 ParseMeasurementPersistentConfigData::readHostIp(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   uint32_t word = read_write_helper::readUint32LittleEndian(data_ptr + 8);
   boost::asio::ip::address_v4 addr(word);
@@ -110,31 +110,31 @@ boost::asio::ip::address_v4 ParseMeasurementPersistentConfigData::readHostIp(
 }
 
 uint16_t ParseMeasurementPersistentConfigData::readHostPort(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 12);
 }
 
 uint16_t ParseMeasurementPersistentConfigData::readPublishingFreq(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 14);
 }
 
 uint32_t ParseMeasurementPersistentConfigData::readStartAngle(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 16);
 }
 
 uint32_t ParseMeasurementPersistentConfigData::readEndAngle(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 20);
 }
 
 uint16_t ParseMeasurementPersistentConfigData::readFeatures(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   // TODO parse Features
   return read_write_helper::readUint16LittleEndian(data_ptr + 24);

--- a/src/data_processing/ParseMonitoringCaseData.cpp
+++ b/src/data_processing/ParseMonitoringCaseData.cpp
@@ -44,7 +44,7 @@ ParseMonitoringCaseData::ParseMonitoringCaseData() {}
 
 bool ParseMonitoringCaseData::parseTCPSequence(
   const datastructure::PacketBuffer& buffer,
-  sick::datastructure::MonitoringCaseData& monitoring_case_data) const
+  sick::datastructure::MonitoringCaseData& monitoring_case_data)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -68,7 +68,7 @@ bool ParseMonitoringCaseData::parseTCPSequence(
   return true;
 }
 
-bool ParseMonitoringCaseData::isValid(std::vector<uint8_t>::const_iterator data_ptr) const
+bool ParseMonitoringCaseData::isValid(std::vector<uint8_t>::const_iterator data_ptr)
 {
   bool res     = false;
   uint8_t byte = read_write_helper::readUint8(data_ptr + 0);
@@ -80,19 +80,19 @@ bool ParseMonitoringCaseData::isValid(std::vector<uint8_t>::const_iterator data_
 }
 
 uint16_t ParseMonitoringCaseData::readMonitoringCaseNumber(
-  std::vector<uint8_t>::const_iterator data_ptr) const
+  std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 6);
 }
 
 uint16_t ParseMonitoringCaseData::readFieldIndex(std::vector<uint8_t>::const_iterator data_ptr,
-                                                 const uint8_t& index) const
+                                                 const uint8_t& index)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 158 + (index * 4));
 }
 
 bool ParseMonitoringCaseData::readFieldValid(std::vector<uint8_t>::const_iterator data_ptr,
-                                             const uint8_t& index) const
+                                             const uint8_t& index)
 {
   uint8_t byte = read_write_helper::readUint8(data_ptr + 157 + (index * 4));
 

--- a/src/data_processing/ParseOrderNumber.cpp
+++ b/src/data_processing/ParseOrderNumber.cpp
@@ -43,7 +43,7 @@ ParseOrderNumber::ParseOrderNumber() {}
 
 
 bool ParseOrderNumber::parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                                        datastructure::OrderNumber& order_number) const
+                                        datastructure::OrderNumber& order_number)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -53,7 +53,7 @@ bool ParseOrderNumber::parseTCPSequence(const datastructure::PacketBuffer& buffe
 }
 
 
-std::string ParseOrderNumber::readOrderNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+std::string ParseOrderNumber::readOrderNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   uint16_t string_length = read_write_helper::readUint16LittleEndian(data_ptr + 0);
 

--- a/src/data_processing/ParseProjectName.cpp
+++ b/src/data_processing/ParseProjectName.cpp
@@ -43,7 +43,7 @@ ParseProjectName::ParseProjectName() {}
 
 
 bool ParseProjectName::parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                                        datastructure::ProjectName& project_name) const
+                                        datastructure::ProjectName& project_name)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -53,7 +53,7 @@ bool ParseProjectName::parseTCPSequence(const datastructure::PacketBuffer& buffe
 }
 
 
-std::string ParseProjectName::readProjectName(std::vector<uint8_t>::const_iterator data_ptr) const
+std::string ParseProjectName::readProjectName(std::vector<uint8_t>::const_iterator data_ptr)
 {
   uint16_t string_length = read_write_helper::readUint16LittleEndian(data_ptr + 0);
 

--- a/src/data_processing/ParseRequiredUserAction.cpp
+++ b/src/data_processing/ParseRequiredUserAction.cpp
@@ -44,7 +44,7 @@ ParseRequiredUserActionData::ParseRequiredUserActionData() {}
 
 bool ParseRequiredUserActionData::parseTCPSequence(
   const datastructure::PacketBuffer& buffer,
-  sick::datastructure::RequiredUserAction& required_user_action) const
+  sick::datastructure::RequiredUserAction& required_user_action)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -55,7 +55,7 @@ bool ParseRequiredUserActionData::parseTCPSequence(
 
 bool ParseRequiredUserActionData::readRequiredUserAction(
   std::vector<uint8_t>::const_iterator data_ptr,
-  sick::datastructure::RequiredUserAction& required_user_action) const
+  sick::datastructure::RequiredUserAction& required_user_action)
 {
   uint16_t word = read_write_helper::readUint16LittleEndian(data_ptr + 0);
 

--- a/src/data_processing/ParseSerialNumber.cpp
+++ b/src/data_processing/ParseSerialNumber.cpp
@@ -43,7 +43,7 @@ ParseSerialNumber::ParseSerialNumber() {}
 
 
 bool ParseSerialNumber::parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                                         datastructure::SerialNumber& serial_number) const
+                                         datastructure::SerialNumber& serial_number)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -53,7 +53,7 @@ bool ParseSerialNumber::parseTCPSequence(const datastructure::PacketBuffer& buff
 }
 
 
-std::string ParseSerialNumber::readSerialNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+std::string ParseSerialNumber::readSerialNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   uint16_t string_length = read_write_helper::readUint16LittleEndian(data_ptr + 0);
 

--- a/src/data_processing/ParseStatusOverview.cpp
+++ b/src/data_processing/ParseStatusOverview.cpp
@@ -44,7 +44,7 @@ ParseStatusOverviewData::ParseStatusOverviewData() {}
 
 bool ParseStatusOverviewData::parseTCPSequence(
   const datastructure::PacketBuffer& buffer,
-  sick::datastructure::StatusOverview& status_overview) const
+  sick::datastructure::StatusOverview& status_overview)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -66,7 +66,7 @@ bool ParseStatusOverviewData::parseTCPSequence(
 }
 
 std::string
-ParseStatusOverviewData::readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseStatusOverviewData::readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr)
 {
   std::string result;
   result.push_back(read_write_helper::readUint8(data_ptr + 0));
@@ -74,73 +74,73 @@ ParseStatusOverviewData::readVersionIndicator(std::vector<uint8_t>::const_iterat
 }
 
 uint8_t
-ParseStatusOverviewData::readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseStatusOverviewData::readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 1);
 }
 
 uint8_t
-ParseStatusOverviewData::readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseStatusOverviewData::readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 2);
 }
 
 uint8_t
-ParseStatusOverviewData::readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseStatusOverviewData::readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 3);
 }
 
 uint8_t
-ParseStatusOverviewData::readDeviceState(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseStatusOverviewData::readDeviceState(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 4);
 }
 
 uint8_t
-ParseStatusOverviewData::readConfigState(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseStatusOverviewData::readConfigState(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 5);
 }
 
 uint8_t
-ParseStatusOverviewData::readApplicationState(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseStatusOverviewData::readApplicationState(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 6);
 }
 
 uint32_t
-ParseStatusOverviewData::readPowerOnCount(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseStatusOverviewData::readPowerOnCount(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 12);
 }
 
 uint32_t
-ParseStatusOverviewData::readCurrentTime(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseStatusOverviewData::readCurrentTime(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 16);
 }
 
 uint16_t
-ParseStatusOverviewData::readCurrentDate(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseStatusOverviewData::readCurrentDate(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 20);
 }
 
 uint32_t
-ParseStatusOverviewData::readErrorInfoCode(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseStatusOverviewData::readErrorInfoCode(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 24);
 }
 
 uint32_t
-ParseStatusOverviewData::readErrorInfoTime(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseStatusOverviewData::readErrorInfoTime(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 52);
 }
 
 uint16_t
-ParseStatusOverviewData::readErrorInfoDate(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseStatusOverviewData::readErrorInfoDate(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16LittleEndian(data_ptr + 56);
 }

--- a/src/data_processing/ParseTCPPacket.cpp
+++ b/src/data_processing/ParseTCPPacket.cpp
@@ -49,7 +49,7 @@ uint32_t ParseTCPPacket::getExpectedPacketLength(const datastructure::PacketBuff
   return readLength(data_ptr) + 8; // for STX and Length which is not included in length datafield
 }
 
-uint16_t ParseTCPPacket::getRequestID(const datastructure::PacketBuffer& buffer) const
+uint16_t ParseTCPPacket::getRequestID(const datastructure::PacketBuffer& buffer)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -59,7 +59,7 @@ uint16_t ParseTCPPacket::getRequestID(const datastructure::PacketBuffer& buffer)
 
 
 bool ParseTCPPacket::parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                                      sick::cola2::Command& command) const
+                                      sick::cola2::Command& command)
 {
   setCommandValuesFromPacket(buffer, command);
 
@@ -70,7 +70,7 @@ bool ParseTCPPacket::parseTCPSequence(const datastructure::PacketBuffer& buffer,
 }
 
 void ParseTCPPacket::setCommandValuesFromPacket(const sick::datastructure::PacketBuffer& buffer,
-                                                sick::cola2::Command& command) const
+                                                sick::cola2::Command& command)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -81,48 +81,48 @@ void ParseTCPPacket::setCommandValuesFromPacket(const sick::datastructure::Packe
   command.setCommandMode(readCommandMode(data_ptr));
 }
 
-uint32_t ParseTCPPacket::readSTx(std::vector<uint8_t>::const_iterator data_ptr) const
+uint32_t ParseTCPPacket::readSTx(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32BigEndian(data_ptr + 0);
 }
 
-uint32_t ParseTCPPacket::readLength(std::vector<uint8_t>::const_iterator data_ptr) const
+uint32_t ParseTCPPacket::readLength(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32BigEndian(data_ptr + 4);
 }
 
-uint8_t ParseTCPPacket::readHubCntr(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseTCPPacket::readHubCntr(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8BigEndian(data_ptr + 8);
 }
-uint8_t ParseTCPPacket::readNoC(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseTCPPacket::readNoC(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8BigEndian(data_ptr + 9);
 }
-uint32_t ParseTCPPacket::readSessionID(std::vector<uint8_t>::const_iterator data_ptr) const
+uint32_t ParseTCPPacket::readSessionID(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32BigEndian(data_ptr + 10);
 }
 
-uint16_t ParseTCPPacket::readRequestID(std::vector<uint8_t>::const_iterator data_ptr) const
+uint16_t ParseTCPPacket::readRequestID(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16BigEndian(data_ptr + 14);
 }
 
-uint8_t ParseTCPPacket::readCommandType(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseTCPPacket::readCommandType(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8BigEndian(data_ptr + 16);
 }
-uint8_t ParseTCPPacket::readCommandMode(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseTCPPacket::readCommandMode(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8BigEndian(data_ptr + 17);
 }
-uint16_t ParseTCPPacket::readErrorCode(std::vector<uint8_t>::const_iterator data_ptr) const
+uint16_t ParseTCPPacket::readErrorCode(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint16BigEndian(data_ptr + 18);
 }
 
-std::vector<uint8_t> ParseTCPPacket::readData(const datastructure::PacketBuffer& buffer) const
+std::vector<uint8_t> ParseTCPPacket::readData(const datastructure::PacketBuffer& buffer)
 {
   if (buffer.getLength() < 20)
   {

--- a/src/data_processing/ParseTypeCodeData.cpp
+++ b/src/data_processing/ParseTypeCodeData.cpp
@@ -43,7 +43,7 @@ ParseTypeCodeData::ParseTypeCodeData() {}
 
 
 bool ParseTypeCodeData::parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                                         sick::datastructure::TypeCode& type_code) const
+                                         sick::datastructure::TypeCode& type_code)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -54,7 +54,7 @@ bool ParseTypeCodeData::parseTCPSequence(const datastructure::PacketBuffer& buff
   return true;
 }
 
-std::string ParseTypeCodeData::readTypeCode(std::vector<uint8_t>::const_iterator data_ptr) const
+std::string ParseTypeCodeData::readTypeCode(std::vector<uint8_t>::const_iterator data_ptr)
 {
   uint16_t code_length = read_write_helper::readUint16LittleEndian(data_ptr);
   std::string code;
@@ -65,7 +65,7 @@ std::string ParseTypeCodeData::readTypeCode(std::vector<uint8_t>::const_iterator
   return code;
 }
 
-uint8_t ParseTypeCodeData::readInterfaceType(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseTypeCodeData::readInterfaceType(std::vector<uint8_t>::const_iterator data_ptr)
 {
   uint8_t type_code_interface_1 = read_write_helper::readUint8(data_ptr + 14);
   uint8_t type_code_interface_2 = read_write_helper::readUint8(data_ptr + 15);
@@ -94,7 +94,7 @@ uint8_t ParseTypeCodeData::readInterfaceType(std::vector<uint8_t>::const_iterato
   return res;
 }
 
-float ParseTypeCodeData::readMaxRange(std::vector<uint8_t>::const_iterator data_ptr) const
+float ParseTypeCodeData::readMaxRange(std::vector<uint8_t>::const_iterator data_ptr)
 {
   uint8_t type_code_interface_1 = read_write_helper::readUint8(data_ptr + 12);
   uint8_t type_code_interface_2 = read_write_helper::readUint8(data_ptr + 13);

--- a/src/data_processing/ParseUserNameData.cpp
+++ b/src/data_processing/ParseUserNameData.cpp
@@ -43,7 +43,7 @@ ParseUserNameData::ParseUserNameData() {}
 
 
 bool ParseUserNameData::parseTCPSequence(const datastructure::PacketBuffer& buffer,
-                                         sick::datastructure::UserName& user_name) const
+                                         sick::datastructure::UserName& user_name)
 {
   // Keep our own copy of the shared_ptr to keep the iterators valid
   const std::shared_ptr<std::vector<uint8_t> const> vec_ptr = buffer.getBuffer();
@@ -58,35 +58,34 @@ bool ParseUserNameData::parseTCPSequence(const datastructure::PacketBuffer& buff
 }
 
 std::string
-ParseUserNameData::readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr) const
+ParseUserNameData::readVersionIndicator(std::vector<uint8_t>::const_iterator data_ptr)
 {
   std::string result;
   result.push_back(read_write_helper::readUint8(data_ptr + 0));
   return result;
 }
 
-uint8_t ParseUserNameData::readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseUserNameData::readMajorNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 1);
 }
 
-uint8_t ParseUserNameData::readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseUserNameData::readMinorNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 2);
 }
 
-uint8_t ParseUserNameData::readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr) const
+uint8_t ParseUserNameData::readReleaseNumber(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint8(data_ptr + 3);
 }
 
-uint32_t ParseUserNameData::readNameLength(std::vector<uint8_t>::const_iterator data_ptr) const
+uint32_t ParseUserNameData::readNameLength(std::vector<uint8_t>::const_iterator data_ptr)
 {
   return read_write_helper::readUint32LittleEndian(data_ptr + 4);
 }
 
-
-std::string ParseUserNameData::readUserName(std::vector<uint8_t>::const_iterator data_ptr) const
+std::string ParseUserNameData::readUserName(std::vector<uint8_t>::const_iterator data_ptr)
 {
   uint32_t name_length = read_write_helper::readUint32LittleEndian(data_ptr + 4);
   std::string name;

--- a/src/data_processing/UDPPacketMerger.cpp
+++ b/src/data_processing/UDPPacketMerger.cpp
@@ -64,8 +64,8 @@ bool UDPPacketMerger::addUDPPacket(const datastructure::PacketBuffer& buffer)
     m_is_complete = false;
   }
   sick::datastructure::DatagramHeader datagram_header;
-  sick::data_processing::ParseDatagramHeader datagram_header_parser;
-  datagram_header_parser.parseUDPSequence(buffer, datagram_header);
+  sick::data_processing::ParseDatagramHeader::parseUDPSequence(buffer, datagram_header);
+
   addToMap(buffer, datagram_header);
   deployPacketIfComplete(datagram_header);
 

--- a/src/datastructure/ApplicationData.cpp
+++ b/src/datastructure/ApplicationData.cpp
@@ -42,7 +42,7 @@ ApplicationData::ApplicationData()
 {
 }
 
-ApplicationInputs ApplicationData::getInputs() const
+const ApplicationInputs&  ApplicationData::getInputs() const
 {
   return m_inputs;
 }
@@ -52,7 +52,7 @@ void ApplicationData::setInputs(const ApplicationInputs& inputs)
   m_inputs = inputs;
 }
 
-ApplicationOutputs ApplicationData::getOutputs() const
+const ApplicationOutputs& ApplicationData::getOutputs() const
 {
   return m_outputs;
 }

--- a/src/datastructure/ApplicationInputs.cpp
+++ b/src/datastructure/ApplicationInputs.cpp
@@ -39,7 +39,7 @@ namespace datastructure {
 
 ApplicationInputs::ApplicationInputs() {}
 
-std::vector<bool> ApplicationInputs::getUnsafeInputsInputSourcesVector() const
+const std::vector<bool>& ApplicationInputs::getUnsafeInputsInputSourcesVector() const
 {
   return m_unsafe_inputs_input_sources_vector;
 }
@@ -50,7 +50,7 @@ void ApplicationInputs::setUnsafeInputsInputSourcesVector(
   m_unsafe_inputs_input_sources_vector = unsafe_inputs_input_sources_vector;
 }
 
-std::vector<bool> ApplicationInputs::getUnsafeInputsFlagsVector() const
+const std::vector<bool>& ApplicationInputs::getUnsafeInputsFlagsVector() const
 {
   return m_unsafe_inputs_flags_vector;
 }
@@ -61,7 +61,7 @@ void ApplicationInputs::setUnsafeInputsFlagsVector(
   m_unsafe_inputs_flags_vector = unsafe_inputs_flags_vector;
 }
 
-std::vector<uint16_t> ApplicationInputs::getMonitoringCasevector() const
+const std::vector<uint16_t>& ApplicationInputs::getMonitoringCasevector() const
 {
   return m_monitoring_case_vector;
 }
@@ -71,7 +71,7 @@ void ApplicationInputs::setMonitoringCaseVector(const std::vector<uint16_t>& mon
   m_monitoring_case_vector = monitoring_case_vector;
 }
 
-std::vector<bool> ApplicationInputs::getMonitoringCaseFlagsVector() const
+const std::vector<bool>& ApplicationInputs::getMonitoringCaseFlagsVector() const
 {
   return m_monitoring_case_flags_vector;
 }

--- a/src/datastructure/ApplicationName.cpp
+++ b/src/datastructure/ApplicationName.cpp
@@ -39,7 +39,7 @@ namespace datastructure {
 
 ApplicationName::ApplicationName() {}
 
-std::string ApplicationName::getVersionCVersion() const
+const std::string& ApplicationName::getVersionCVersion() const
 {
   return m_version_c_version;
 }
@@ -89,7 +89,7 @@ void ApplicationName::setNameLength(const uint32_t& name_length)
   m_name_length = name_length;
 }
 
-std::string ApplicationName::getApplicationName() const
+const std::string& ApplicationName::getApplicationName() const
 {
   return m_application_name;
 }

--- a/src/datastructure/ApplicationOutputs.cpp
+++ b/src/datastructure/ApplicationOutputs.cpp
@@ -39,7 +39,7 @@ namespace datastructure {
 
 ApplicationOutputs::ApplicationOutputs() {}
 
-std::vector<bool> ApplicationOutputs::getEvalOutVector() const
+const std::vector<bool>& ApplicationOutputs::getEvalOutVector() const
 {
   return m_eval_out_vector;
 }
@@ -49,7 +49,7 @@ void ApplicationOutputs::setEvalOutVector(const std::vector<bool>& eval_out_vect
   m_eval_out_vector = eval_out_vector;
 }
 
-std::vector<bool> ApplicationOutputs::getEvalOutIsSafeVector() const
+const std::vector<bool>& ApplicationOutputs::getEvalOutIsSafeVector() const
 {
   return m_eval_out_is_safe_vector;
 }
@@ -59,7 +59,7 @@ void ApplicationOutputs::setEvalOutIsSafeVector(const std::vector<bool>& eval_ou
   m_eval_out_is_safe_vector = eval_out_is_safe_vector;
 }
 
-std::vector<bool> ApplicationOutputs::getEvalOutIsValidVector() const
+const std::vector<bool>& ApplicationOutputs::getEvalOutIsValidVector() const
 {
   return m_eval_out_is_valid_vector;
 }
@@ -69,7 +69,7 @@ void ApplicationOutputs::setEvalOutIsValidVector(const std::vector<bool>& eval_o
   m_eval_out_is_valid_vector = eval_out_is_valid_vector;
 }
 
-std::vector<uint16_t> ApplicationOutputs::getMonitoringCaseVector() const
+const std::vector<uint16_t>& ApplicationOutputs::getMonitoringCaseVector() const
 {
   return m_monitoring_case_vector;
 }
@@ -80,7 +80,7 @@ void ApplicationOutputs::setMonitoringCaseVector(
   m_monitoring_case_vector = monitoring_case_vector;
 }
 
-std::vector<bool> ApplicationOutputs::getMonitoringCaseFlagsVector() const
+const std::vector<bool>& ApplicationOutputs::getMonitoringCaseFlagsVector() const
 {
   return m_monitoring_case_flags_vector;
 }
@@ -224,7 +224,7 @@ void ApplicationOutputs::setVelocity1TransmittedSafely(bool velocity_1_transmitt
   m_velocity_1_transmitted_safely = velocity_1_transmitted_safely;
 }
 
-std::vector<int16_t> ApplicationOutputs::getResultingVelocityVector() const
+const std::vector<int16_t>& ApplicationOutputs::getResultingVelocityVector() const
 {
   return m_resulting_velocity_vector;
 }
@@ -235,7 +235,7 @@ void ApplicationOutputs::setResultingVelocityVector(
   m_resulting_velocity_vector = resulting_velocity_vector;
 }
 
-std::vector<bool> ApplicationOutputs::getResultingVelocityIsValidVector() const
+const std::vector<bool>& ApplicationOutputs::getResultingVelocityIsValidVector() const
 {
   return m_resulting_velocity_is_valid_vector;
 }

--- a/src/datastructure/CommSettings.cpp
+++ b/src/datastructure/CommSettings.cpp
@@ -32,6 +32,8 @@
  */
 //----------------------------------------------------------------------
 
+#include <cmath>
+
 #include <sick_safetyscanners_base/datastructure/CommSettings.h>
 
 namespace sick {
@@ -123,24 +125,24 @@ void CommSettings::setPublishingFrequency(const uint16_t& publishing_frequency)
   m_publishing_frequency = publishing_frequency;
 }
 
-uint32_t CommSettings::getStartAngle() const
+int32_t CommSettings::getStartAngle() const
 {
   return m_start_angle;
 }
 
-void CommSettings::setStartAngle(const uint32_t& start_angle)
+void CommSettings::setStartAngle(const float& start_angle)
 {
-  m_start_angle = start_angle * 4194304.0; // TODO refactor in constant
+  m_start_angle = std::floor( start_angle * 4194304 ); // TODO refactor in constant
 }
 
-uint32_t CommSettings::getEndAngle() const
+int32_t CommSettings::getEndAngle() const
 {
   return m_end_angle;
 }
 
-void CommSettings::setEndAngle(const uint32_t& end_angle)
+void CommSettings::setEndAngle(const float& end_angle)
 {
-  m_end_angle = end_angle * 4194304.0;
+  m_end_angle = std::ceil( end_angle * 4194304 );
 }
 
 uint16_t CommSettings::getFeatures() const

--- a/src/datastructure/ConfigData.cpp
+++ b/src/datastructure/ConfigData.cpp
@@ -39,7 +39,7 @@ namespace datastructure {
 
 ConfigData::ConfigData() {}
 
-std::string ConfigData::getVersionCVersion() const
+const std::string& ConfigData::getVersionCVersion() const
 {
   return m_version_c_version;
 }

--- a/src/datastructure/ConfigMetadata.cpp
+++ b/src/datastructure/ConfigMetadata.cpp
@@ -39,7 +39,7 @@ namespace datastructure {
 
 ConfigMetadata::ConfigMetadata() {}
 
-std::string ConfigMetadata::getVersionCVersion() const
+const std::string& ConfigMetadata::getVersionCVersion() const
 {
   return m_version_c_version;
 }
@@ -139,7 +139,7 @@ void ConfigMetadata::setOverallChecksum(const uint32_t& overall_checksum)
   m_overall_checksum = overall_checksum;
 }
 
-std::vector<uint32_t> ConfigMetadata::getIntegrityHash() const
+const std::vector<uint32_t>& ConfigMetadata::getIntegrityHash() const
 {
   return m_integrity_hash;
 }

--- a/src/datastructure/DeviceName.cpp
+++ b/src/datastructure/DeviceName.cpp
@@ -39,7 +39,7 @@ namespace datastructure {
 
 DeviceName::DeviceName() {}
 
-std::string DeviceName::getDeviceName() const
+const std::string& DeviceName::getDeviceName() const
 {
   return m_device_name;
 }

--- a/src/datastructure/FieldData.cpp
+++ b/src/datastructure/FieldData.cpp
@@ -49,7 +49,7 @@ void FieldData::setIsValid(bool is_valid)
   m_is_valid = is_valid;
 }
 
-std::string FieldData::getVersionCVersion() const
+const std::string& FieldData::getVersionCVersion() const
 {
   return m_version_c_version;
 }
@@ -149,7 +149,7 @@ void FieldData::setNameLength(const uint32_t& name_length)
   m_name_length = name_length;
 }
 
-std::string FieldData::getFieldName() const
+const std::string& FieldData::getFieldName() const
 {
   return m_field_name;
 }
@@ -180,7 +180,7 @@ void FieldData::setIsProtectiveField(bool is_protective_field)
   m_is_protective_field = is_protective_field;
 }
 
-std::vector<uint16_t> FieldData::getBeamDistances() const
+const std::vector<uint16_t>& FieldData::getBeamDistances() const
 {
   return m_beam_distances;
 }

--- a/src/datastructure/FieldSets.cpp
+++ b/src/datastructure/FieldSets.cpp
@@ -39,7 +39,7 @@ namespace datastructure {
 
 FieldSets::FieldSets() {}
 
-std::string FieldSets::getVersionCVersion() const
+const std::string& FieldSets::getVersionCVersion() const
 {
   return m_version_c_version;
 }
@@ -79,7 +79,7 @@ void FieldSets::setVersionReleaseNumber(const uint8_t& version_release_number)
   m_version_release_number = version_release_number;
 }
 
-std::vector<uint32_t> FieldSets::getNameLength() const
+const std::vector<uint32_t>& FieldSets::getNameLength() const
 {
   return m_name_length;
 }
@@ -89,7 +89,7 @@ void FieldSets::setNameLength(const std::vector<uint32_t>& name_length)
   m_name_length = name_length;
 }
 
-std::vector<std::string> FieldSets::getFieldName() const
+const std::vector<std::string>& FieldSets::getFieldName() const
 {
   return m_field_name;
 }
@@ -99,7 +99,7 @@ void FieldSets::setFieldName(const std::vector<std::string>& field_name)
   m_field_name = field_name;
 }
 
-std::vector<bool> FieldSets::getIsDefined() const
+const std::vector<bool>& FieldSets::getIsDefined() const
 {
   return m_is_defined;
 }

--- a/src/datastructure/FirmwareVersion.cpp
+++ b/src/datastructure/FirmwareVersion.cpp
@@ -39,7 +39,7 @@ namespace datastructure {
 
 FirmwareVersion::FirmwareVersion() {}
 
-std::string FirmwareVersion::getFirmwareVersion() const
+const std::string& FirmwareVersion::getFirmwareVersion() const
 {
   return m_firmware_version;
 }

--- a/src/datastructure/GeneralSystemState.cpp
+++ b/src/datastructure/GeneralSystemState.cpp
@@ -102,7 +102,7 @@ void GeneralSystemState::setManipulationStatus(bool manipulation_status)
   m_manipulation_status = manipulation_status;
 }
 
-std::vector<bool> GeneralSystemState::getSafeCutOffPathVector() const
+const std::vector<bool>& GeneralSystemState::getSafeCutOffPathVector() const
 {
   return m_safe_cut_off_path_vector;
 }
@@ -112,7 +112,7 @@ void GeneralSystemState::setSafeCutOffPathvector(const std::vector<bool>& safe_c
   m_safe_cut_off_path_vector = safe_cut_off_path_vector;
 }
 
-std::vector<bool> GeneralSystemState::getNonSafeCutOffPathVector() const
+const std::vector<bool>& GeneralSystemState::getNonSafeCutOffPathVector() const
 {
   return m_non_safe_cut_off_path_vector;
 }
@@ -123,7 +123,7 @@ void GeneralSystemState::setNonSafeCutOffPathVector(
   m_non_safe_cut_off_path_vector = non_safe_cut_off_path_vector;
 }
 
-std::vector<bool> GeneralSystemState::getResetRequiredCutOffPathVector() const
+const std::vector<bool>& GeneralSystemState::getResetRequiredCutOffPathVector() const
 {
   return m_reset_required_cut_off_path_vector;
 }

--- a/src/datastructure/IntrusionData.cpp
+++ b/src/datastructure/IntrusionData.cpp
@@ -42,7 +42,7 @@ IntrusionData::IntrusionData()
 {
 }
 
-std::vector<IntrusionDatum> IntrusionData::getIntrusionDataVector() const
+const std::vector<IntrusionDatum>& IntrusionData::getIntrusionDataVector() const
 {
   return m_intrusion_data_vector;
 }

--- a/src/datastructure/IntrusionDatum.cpp
+++ b/src/datastructure/IntrusionDatum.cpp
@@ -50,7 +50,7 @@ void IntrusionDatum::setSize(const int32_t& size)
   m_size = size;
 }
 
-std::vector<bool> IntrusionDatum::getFlagsVector() const
+const std::vector<bool>& IntrusionDatum::getFlagsVector() const
 {
   return m_flags_vector;
 }

--- a/src/datastructure/MeasurementData.cpp
+++ b/src/datastructure/MeasurementData.cpp
@@ -53,7 +53,7 @@ void MeasurementData::setNumberOfBeams(const uint32_t& number_of_beams)
   m_number_of_beams = number_of_beams;
 }
 
-std::vector<ScanPoint> MeasurementData::getScanPointsVector() const
+const std::vector<ScanPoint>& MeasurementData::getScanPointsVector() const
 {
   return m_scan_points_vector;
 }

--- a/src/datastructure/MonitoringCaseData.cpp
+++ b/src/datastructure/MonitoringCaseData.cpp
@@ -59,7 +59,7 @@ void MonitoringCaseData::setMonitoringCaseNumber(const uint16_t& monitoring_case
   m_monitoring_case_number = monitoring_case_number;
 }
 
-std::vector<uint16_t> MonitoringCaseData::getFieldIndices() const
+const std::vector<uint16_t>& MonitoringCaseData::getFieldIndices() const
 {
   return m_field_indices;
 }
@@ -69,7 +69,7 @@ void MonitoringCaseData::setFieldIndices(const std::vector<uint16_t>& field_indi
   m_field_indices = field_indices;
 }
 
-std::vector<bool> MonitoringCaseData::getFieldsValid() const
+const std::vector<bool>& MonitoringCaseData::getFieldsValid() const
 {
   return m_fields_valid;
 }

--- a/src/datastructure/OrderNumber.cpp
+++ b/src/datastructure/OrderNumber.cpp
@@ -39,7 +39,7 @@ namespace datastructure {
 
 OrderNumber::OrderNumber() {}
 
-std::string OrderNumber::getOrderNumber() const
+const std::string& OrderNumber::getOrderNumber() const
 {
   return m_order_number;
 }

--- a/src/datastructure/ProjectName.cpp
+++ b/src/datastructure/ProjectName.cpp
@@ -39,7 +39,7 @@ namespace datastructure {
 
 ProjectName::ProjectName() {}
 
-std::string ProjectName::getProjectName() const
+const std::string& ProjectName::getProjectName() const
 {
   return m_project_name;
 }

--- a/src/datastructure/SerialNumber.cpp
+++ b/src/datastructure/SerialNumber.cpp
@@ -39,7 +39,7 @@ namespace datastructure {
 
 SerialNumber::SerialNumber() {}
 
-std::string SerialNumber::getSerialNumber() const
+const std::string& SerialNumber::getSerialNumber() const
 {
   return m_serial_number;
 }

--- a/src/datastructure/StatusOverview.cpp
+++ b/src/datastructure/StatusOverview.cpp
@@ -39,7 +39,7 @@ namespace datastructure {
 
 StatusOverview::StatusOverview() {}
 
-std::string StatusOverview::getVersionCVersion() const
+const std::string& StatusOverview::getVersionCVersion() const
 {
   return m_version_c_version;
 }

--- a/src/datastructure/TypeCode.cpp
+++ b/src/datastructure/TypeCode.cpp
@@ -39,7 +39,7 @@ namespace datastructure {
 
 TypeCode::TypeCode() {}
 
-std::string TypeCode::getTypeCode() const
+const std::string& TypeCode::getTypeCode() const
 {
   return m_type_code;
 }

--- a/src/datastructure/UserName.cpp
+++ b/src/datastructure/UserName.cpp
@@ -39,7 +39,7 @@ namespace datastructure {
 
 UserName::UserName() {}
 
-std::string UserName::getVersionCVersion() const
+const std::string& UserName::getVersionCVersion() const
 {
   return m_version_c_version;
 }
@@ -89,7 +89,7 @@ void UserName::setNameLength(const uint32_t& name_length)
   m_name_length = name_length;
 }
 
-std::string UserName::getUserName() const
+const std::string& UserName::getUserName() const
 {
   return m_user_name;
 }


### PR DESCRIPTION
Hi,

i was in contact with Nicolas Loeffler before the official release of the lib and he has provided me with an preview version of the lib. I integrated the lib in our Software (non ROS) and made some changes to the lib I now propose to add to the mainline driver, because I think they offer some benefits.

This pull request is mainly to start the discussion what and how we could integrate some, or all changes into the mainline driver.

The main things I have clanged are:
- Made all DataParser method to be static methods, because they do not work on class variables. Thus the class must be not instantiated and no memory must be allocated.
- Made the Getters in DataStructure to return a const &. This prevents unnecessary data copy.
- I moved all logging includes into the cpp files. If logging includes are in the header file the c++ using the lib must also define WITHOUT_ROS_LOGGING. Otherwise the ROS headers are included. With all logging headers only in the cpp this is not required. I also added a WITHOUT_LOGGING define that disables all logging output.
- BUGFIX: uint32 was used for start/end angle in CommSettings but the protocol description from SICK uses int32 for this values. Thus it was not possible to use a negative start angle.
- I added a asynchronous interface to SickSafetyscannersBase which allows the lib to be used in synchronous and asynchronous use cases.
- I did some cleanup with the use of the io_service because it was sometimes not used as proposed in the boost docu
- I also added the possibility to inject an external io_service which does not create an additional thread within the lib

I hope to discuss the proposed changes further so that we can improve the lib together.