### PR TITLE
Fix memory leak in createAndExecuteCommand

### DIFF
--- a/include/sick_safetyscanners_base/SickSafetyscanners.h
+++ b/include/sick_safetyscanners_base/SickSafetyscanners.h
@@ -278,8 +278,8 @@ private:
   void inline createAndExecuteCommand(Args&&... args)
   {
     m_session.open();
-    auto cmd = new CommandT(std::forward<Args>(args)...);
-    m_session.sendCommand(*cmd);
+    CommandT cmd(std::forward<Args>(args)...);
+    m_session.sendCommand(cmd);
     m_session.close();
   }
 


### PR DESCRIPTION
Hello!

I was working with this library in a project and noticed that there is a memory leak in createAndExecuteCommand: the command is allocated on the heap and never deleted.

It's a slow leak, but the fix is simple enough.  I tested this on my system (Ubuntu 18.04, MS3 Pro 5.5 meter) and verified I could still receive UDP and send/receive TCP data with this change.  