### PR TITLE
Added missing 'using' statement to UDPClient.cpp

### DIFF
--- a/src/communication/UDPClient.cpp
+++ b/src/communication/UDPClient.cpp
@@ -56,6 +56,7 @@ namespace communication {
 using boost::asio::deadline_timer;
 using boost::asio::ip::tcp;
 using boost::lambda::_1;
+using boost::lambda::_2;
 using boost::lambda::bind;
 using boost::lambda::var;
 


### PR DESCRIPTION
This is needed when building with newer versions of boost, since they have removed the global aliases of various identifiers (e.g. when building on Ubuntu Jammy)