### PR TITLE
UDPPacketMerger: fixing missing include

### DIFF
--- a/include/sick_safetyscanners_base/data_processing/UDPPacketMerger.h
+++ b/include/sick_safetyscanners_base/data_processing/UDPPacketMerger.h
@@ -42,6 +42,7 @@
 
 #include <algorithm>
 #include <mutex>
+#include <map>
 
 namespace sick {
 namespace data_processing {


### PR DESCRIPTION
While std::map is used, it is not included in this header. This leads to this error with gcc 11.2:

| In file included from /yocto/sf-build/BUILD-ros2-humble-honister/work/core2-64-oe-linux/sick-safetyscanners-base/1.0.2-1-r0/git/src/data_processing/UDPPacketMerger.cpp:35: | /yocto/sf-build/BUILD-ros2-humble-honister/work/core2-64-oe-linux/sick-safetyscanners-base/1.0.2-1-r0/git/include/sick_safetyscanners_base/data_processing/UDPPacketMerger.h:87:8: error: 'map' in namespace 'std' does not name a template type
|    87 |   std::map<uint32_t, sick::datastructure::ParsedPacketBuffer::ParsedPacketBufferVector>
|       |        ^~~
| /yocto/sf-build/BUILD-ros2-humble-honister/work/core2-64-oe-linux/sick-safetyscanners-base/1.0.2-1-r0/git/include/sick_safetyscanners_base/data_processing/UDPPacketMerger.h:42:1: note: 'std::map' is defined in header '<map>'; did you forget to '#include <map>'?
|    41 | #include "sick_safetyscanners_base/data_processing/ParseDatagramHeader.h"
|   +++ |+#include <map>
|    42 |

Signed-off-by: Matthias Schoepfer <m.schoepfer@rethinkrobotics.com>