### PR TITLE
fix: fix clang warnings.

### DIFF
--- a/include/sick_safetyscanners_base/SickSafetyscanners.h
+++ b/include/sick_safetyscanners_base/SickSafetyscanners.h
@@ -62,7 +62,6 @@
 #include "sick_safetyscanners_base/cola2/Command.h"
 #include "sick_safetyscanners_base/datastructure/Datastructure.h"
 
-
 namespace sick {
 
 using io_service_ptr = std::shared_ptr<boost::asio::io_service>;
@@ -262,9 +261,7 @@ public:
 
 private:
   sick::types::ip_address_t m_sensor_ip;
-  sick::types::port_t m_sensor_tcp_port;
   CommSettings m_comm_settings;
-  bool m_is_initialized;
   std::unique_ptr<boost::asio::io_service> m_io_service_ptr;
 
   /*!

--- a/src/SickSafetyscanners.cpp
+++ b/src/SickSafetyscanners.cpp
@@ -45,13 +45,12 @@ SickSafetyscannersBase::SickSafetyscannersBase(sick::types::ip_address_t sensor_
                                                sick::types::port_t sensor_tcp_port,
                                                CommSettings comm_settings)
   : m_sensor_ip(sensor_ip)
-  , m_sensor_tcp_port(sensor_tcp_port)
   , m_comm_settings(comm_settings)
   , m_io_service_ptr(sick::make_unique<boost::asio::io_service>())
   , m_io_service(*m_io_service_ptr)
   , m_udp_client(m_io_service, comm_settings.host_udp_port)
   , m_session(
-      std::move(sick::make_unique<sick::communication::TCPClient>(m_sensor_ip, sensor_tcp_port)))
+      sick::make_unique<sick::communication::TCPClient>(m_sensor_ip, sensor_tcp_port))
   , m_packet_merger()
 {
   changeSensorSettings(comm_settings);
@@ -62,13 +61,12 @@ SickSafetyscannersBase::SickSafetyscannersBase(sick::types::ip_address_t sensor_
                                                CommSettings comm_settings,
                                                boost::asio::ip::address_v4 interface_ip)
   : m_sensor_ip(sensor_ip)
-  , m_sensor_tcp_port(sensor_tcp_port)
   , m_comm_settings(comm_settings)
   , m_io_service_ptr(sick::make_unique<boost::asio::io_service>())
   , m_io_service(*m_io_service_ptr)
   , m_udp_client(m_io_service, comm_settings.host_udp_port, comm_settings.host_ip, interface_ip)
   , m_session(
-      std::move(sick::make_unique<sick::communication::TCPClient>(m_sensor_ip, sensor_tcp_port)))
+      sick::make_unique<sick::communication::TCPClient>(m_sensor_ip, sensor_tcp_port))
   , m_packet_merger()
 {
   changeSensorSettings(comm_settings);
@@ -79,13 +77,12 @@ SickSafetyscannersBase::SickSafetyscannersBase(sick::types::ip_address_t sensor_
                                                CommSettings comm_settings,
                                                boost::asio::io_service& io_service)
   : m_sensor_ip(sensor_ip)
-  , m_sensor_tcp_port(sensor_tcp_port)
   , m_comm_settings(comm_settings)
   , m_io_service_ptr(nullptr)
   , m_io_service(io_service)
   , m_udp_client(m_io_service, comm_settings.host_udp_port)
   , m_session(
-      std::move(sick::make_unique<sick::communication::TCPClient>(m_sensor_ip, sensor_tcp_port)))
+      sick::make_unique<sick::communication::TCPClient>(m_sensor_ip, sensor_tcp_port))
   , m_packet_merger()
 {
   changeSensorSettings(comm_settings);


### PR DESCRIPTION
This should fix https://github.com/SICKAG/sick_safetyscanners_base/issues/9.