### PR TITLE
fix: fix another clang warning.

### DIFF
--- a/src/communication/TCPClient.cpp
+++ b/src/communication/TCPClient.cpp
@@ -130,7 +130,6 @@ void TCPClient::disconnect()
 
 bool TCPClient::isConnected()
 {
-  boost::system::error_code err;
   return m_socket.is_open();
 }
 


### PR DESCRIPTION
In addition to what's mentioned in [#16](https://github.com/SICKAG/sick_safetyscanners_base/pull/16), I encountered another warning.