### PR TITLE
fix(parse-config-metadata): read checksums

### DIFF
--- a/src/data_processing/ParseConfigMetadata.cpp
+++ b/src/data_processing/ParseConfigMetadata.cpp
@@ -112,13 +112,13 @@ ParseConfigMetadata::readTransferTimeTime(std::vector<uint8_t>::const_iterator d
 
 uint32_t ParseConfigMetadata::readAppChecksum(std::vector<uint8_t>::const_iterator data_ptr) const
 {
-  return read_write_helper::readUint32LittleEndian(data_ptr + 36);
+  return read_write_helper::readUint32BigEndian(data_ptr + 36);
 }
 
 uint32_t
 ParseConfigMetadata::readOverallChecksum(std::vector<uint8_t>::const_iterator data_ptr) const
 {
-  return read_write_helper::readUint32LittleEndian(data_ptr + 52);
+  return read_write_helper::readUint32BigEndian(data_ptr + 52);
 }
 
 std::vector<uint32_t>


### PR DESCRIPTION
Same fix as introduced here https://github.com/SICKAG/sick_safetyscanners/pull/126/files