### PR TITLE
Add support for EtherCAT versions

### DIFF
--- a/src/data_processing/ParseTypeCodeData.cpp
+++ b/src/data_processing/ParseTypeCodeData.cpp
@@ -86,7 +86,8 @@ uint8_t ParseTypeCodeData::readInterfaceType(std::vector<uint8_t>::const_iterato
   {
     res = sick::datastructure::e_interface_type::E_PROFINET;
   }
-  else if (type_code_interface_1 == 'A' && type_code_interface_2 == 'N')
+  else if ((type_code_interface_1 == 'A' && type_code_interface_2 == 'N') ||
+           (type_code_interface_1 == 'E' && type_code_interface_2 == 'N'))
   {
     res = sick::datastructure::e_interface_type::E_NONSAFE_ETHERNET;
   }


### PR DESCRIPTION
Closes https://github.com/SICKAG/sick_safetyscanners_base/issues/45

- Adds missing explicit check for EtherCAT modules, which seem to always map to "EN": https://www.sick.com/at/en/products/safety/safety-laser-scanners/microscan3/c/g295657?tab=selection&filters=Product%20version%3C@%3E57155::BooleanFilter::microScan3%20Core%20-%20EtherCAT