### PR TITLE
Fix license in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
 
   <author>Lennart Puck</author>
 
-  <license>ALv2</license>
+  <license>Apache-2.0</license>
   <buildtool_depend>cmake</buildtool_depend>
 
   <depend>libboost-chrono-dev</depend>


### PR DESCRIPTION
Without this change, [ros-license-toolkit](https://github.com/boschresearch/ros_license_toolkit) warns about the license:

```
[sick_safetyscanners_base]
git hash of (/home/src/github.com/SICKAG/sick_safetyscanners_base): 0909d14154742e6b2d97af03110c7bcb54010590
SchemaCheck
 FAILURE package.xml contains errors: /home/wsh/src/github.com/SICKAG/sick_safetyscanners_base/package.xml:11:0:ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element 'author': This element is not expected. Expected is one of ( maintainer, license ).
LicenseTagExistsCheck
 SUCCESS Found licenses ['ALv2']
LicenseTagIsInSpdxListCheck
 WARNING Licenses ['ALv2'] are not in SPDX list of licenses. Make sure to exactly match one of https://spdx.org/licenses/.
LicenseTextExistsCheck
 WARNING Since they are not in the SPDX list, we can not check if these tags have the correct license text:
  'ALv2': License text file 'LICENSE.txt' is of license Apache-2.0 but tag is ALv2.
LicensesInCodeCheck
 WARNING For the following files, please change the License Tag in the package file to SPDX format:
  'include/sick_safetyscanners_base/Exceptions.h' is of Apache-2.0 but its Tag is ALv2.
  'include/sick_safetyscanners_base/Generics.h' is of Apache-2.0 but its Tag is ALv2.
  ....
```

Note that this PR doesn't try to address the `author` failure.
